### PR TITLE
feature: 배너 이미지 조회

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,9 +45,9 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}:prod
 
   deployment:
-      runs-on: ubuntu-latest
-      needs: [ build-docker-image-and-push ]
-      steps:
+    runs-on: ubuntu-latest
+    needs: [ build-docker-image-and-push ]
+    steps:
       - name: Deploy
         uses: appleboy/ssh-action@master
         with:
@@ -57,6 +57,5 @@ jobs:
           script: |
             echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
             cd api/bin/
-            sudo docker compose down
+            sudo docker compose down --rmi all
             sudo docker compose up -d
-            sudo docker image prune -af

--- a/.github/workflows/gradle-CI.yml
+++ b/.github/workflows/gradle-CI.yml
@@ -2,8 +2,6 @@ name: CI With Pull Request
 
 on:
   push:
-  pull_request:
-    types: [opened, reopened]
 
 jobs:
   build:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.3.0")
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.3.0")
 
+    implementation("org.springframework.boot:spring-boot-starter-cache")
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,10 @@ dependencies {
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.3.0")
 
     implementation("org.springframework.boot:spring-boot-starter-cache")
+
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
     testImplementation("io.kotest:kotest-assertions-core:5.4.2")

--- a/src/main/kotlin/com/petqua/application/banner/BannerDtos.kt
+++ b/src/main/kotlin/com/petqua/application/banner/BannerDtos.kt
@@ -3,7 +3,7 @@ package com.petqua.application.banner
 import com.petqua.domain.banner.Banner
 import java.time.LocalDateTime
 
-data class FindBannerResult(
+data class BannerResponse(
     val id: Long,
     val imageUrl: String,
     val linkUrl: String,
@@ -11,8 +11,8 @@ data class FindBannerResult(
     val updateAt: LocalDateTime,
 ) {
     companion object {
-        fun from(banner: Banner): FindBannerResult {
-            return FindBannerResult(
+        fun from(banner: Banner): BannerResponse {
+            return BannerResponse(
                 id = banner.id,
                 imageUrl = banner.imageUrl,
                 linkUrl = banner.linkUrl,

--- a/src/main/kotlin/com/petqua/application/banner/BannerDtos.kt
+++ b/src/main/kotlin/com/petqua/application/banner/BannerDtos.kt
@@ -1,0 +1,24 @@
+package com.petqua.application.banner
+
+import com.petqua.domain.banner.Banner
+import java.time.LocalDateTime
+
+data class FindBannerResult(
+    val id: Long,
+    val imageUrl: String,
+    val linkUrl: String,
+    val createAt: LocalDateTime,
+    val updateAt: LocalDateTime,
+) {
+    companion object {
+        fun from(banner: Banner): FindBannerResult {
+            return FindBannerResult(
+                id = banner.id,
+                imageUrl = banner.imageUrl,
+                linkUrl = banner.linkUrl,
+                createAt = banner.createdAt,
+                updateAt = banner.updatedAt,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/application/banner/BannerService.kt
+++ b/src/main/kotlin/com/petqua/application/banner/BannerService.kt
@@ -13,8 +13,8 @@ class BannerService(
 
     @Cacheable("banners")
     @Transactional(readOnly = true)
-    fun getBannerList(): List<FindBannerResult> {
+    fun readAll(): List<BannerResponse> {
         val banners = bannerRepository.findAll()
-        return banners.map { FindBannerResult.from(it) }
+        return banners.map { BannerResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/petqua/application/banner/BannerService.kt
+++ b/src/main/kotlin/com/petqua/application/banner/BannerService.kt
@@ -1,5 +1,6 @@
 package com.petqua.application.banner
 
+import com.petqua.application.banner.dto.BannerResponse
 import com.petqua.domain.banner.BannerRepository
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/petqua/application/banner/BannerService.kt
+++ b/src/main/kotlin/com/petqua/application/banner/BannerService.kt
@@ -1,0 +1,20 @@
+package com.petqua.application.banner
+
+import com.petqua.domain.banner.BannerRepository
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class BannerService(
+    private val bannerRepository: BannerRepository,
+) {
+
+    @Cacheable("banners")
+    @Transactional(readOnly = true)
+    fun getBannerList(): List<FindBannerResult> {
+        val banners = bannerRepository.findAll()
+        return banners.map { FindBannerResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
+++ b/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
@@ -1,14 +1,11 @@
-package com.petqua.application.banner
+package com.petqua.application.banner.dto
 
 import com.petqua.domain.banner.Banner
-import java.time.LocalDateTime
 
 data class BannerResponse(
     val id: Long,
     val imageUrl: String,
     val linkUrl: String,
-    val createAt: LocalDateTime,
-    val updateAt: LocalDateTime,
 ) {
     companion object {
         fun from(banner: Banner): BannerResponse {
@@ -16,8 +13,6 @@ data class BannerResponse(
                 id = banner.id,
                 imageUrl = banner.imageUrl,
                 linkUrl = banner.linkUrl,
-                createAt = banner.createdAt,
-                updateAt = banner.updatedAt,
             )
         }
     }

--- a/src/main/kotlin/com/petqua/common/cofig/CacheConfiguration.kt
+++ b/src/main/kotlin/com/petqua/common/cofig/CacheConfiguration.kt
@@ -1,0 +1,20 @@
+package com.petqua.common.cofig
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@EnableCaching
+@Configuration
+class CacheConfiguration {
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val cacheManager = ConcurrentMapCacheManager()
+        cacheManager.setCacheNames(listOf("banners"))
+        return cacheManager
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/banner/Banner.kt
+++ b/src/main/kotlin/com/petqua/domain/banner/Banner.kt
@@ -1,0 +1,16 @@
+package com.petqua.domain.banner
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class Banner(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    val imageUrl: String,
+
+    @Column(nullable = false)
+    val linkUrl: String,
+) : BaseEntity()

--- a/src/main/kotlin/com/petqua/domain/banner/Banner.kt
+++ b/src/main/kotlin/com/petqua/domain/banner/Banner.kt
@@ -1,7 +1,11 @@
 package com.petqua.domain.banner
 
 import com.petqua.common.domain.BaseEntity
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 
 @Entity
 class Banner(

--- a/src/main/kotlin/com/petqua/domain/banner/BannerRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/banner/BannerRepository.kt
@@ -1,0 +1,6 @@
+package com.petqua.domain.banner
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BannerRepository: JpaRepository<Banner, Long> {
+}

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -1,7 +1,7 @@
 package com.petqua.presentation.banner
 
-import com.petqua.application.banner.BannerResponse
 import com.petqua.application.banner.BannerService
+import com.petqua.application.banner.dto.BannerResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -1,0 +1,21 @@
+package com.petqua.presentation.banner
+
+import com.petqua.application.banner.BannerService
+import com.petqua.application.banner.FindBannerResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/banner")
+@RestController
+class BannerController(
+    private val bannerService: BannerService
+) {
+
+    @GetMapping
+    fun getBanners(): ResponseEntity<List<FindBannerResult>> {
+        val bannerList = bannerService.getBannerList()
+        return ResponseEntity.ok(bannerList)
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RequestMapping("/banner")
+@RequestMapping("/banners")
 @RestController
 class BannerController(
     private val bannerService: BannerService

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -1,7 +1,7 @@
 package com.petqua.presentation.banner
 
+import com.petqua.application.banner.BannerResponse
 import com.petqua.application.banner.BannerService
-import com.petqua.application.banner.FindBannerResult
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,8 +14,8 @@ class BannerController(
 ) {
 
     @GetMapping
-    fun getBanners(): ResponseEntity<List<FindBannerResult>> {
-        val bannerList = bannerService.getBannerList()
+    fun readAll(): ResponseEntity<List<BannerResponse>> {
+        val bannerList = bannerService.readAll()
         return ResponseEntity.ok(bannerList)
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -15,7 +15,7 @@ class BannerController(
 
     @GetMapping
     fun readAll(): ResponseEntity<List<BannerResponse>> {
-        val bannerList = bannerService.readAll()
-        return ResponseEntity.ok(bannerList)
+        val response = bannerService.readAll()
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
@@ -1,0 +1,47 @@
+package com.petqua.application.banner
+
+import com.petqua.domain.banner.Banner
+import com.petqua.domain.banner.BannerRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito.atMost
+import org.mockito.Mockito.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode.ALL
+
+@TestConstructor(autowireMode = ALL)
+@SpringBootTest(webEnvironment = NONE)
+class BannerServiceTest(
+    private var bannerService: BannerService,
+    @SpyBean private var bannerRepository: BannerRepository,
+) : BehaviorSpec({
+
+    Given("Banner 조회 테스트") {
+        bannerRepository.saveAll(
+            listOf(
+                Banner(imageUrl = "imageUrlA", linkUrl = "linkUrlA"),
+                Banner(imageUrl = "imageUrlB", linkUrl = "linkUrlB"),
+                Banner(imageUrl = "imageUrlC", linkUrl = "linkUrlC"),
+            )
+        )
+
+        When("Banner를 전체 조회 하면") {
+            val results = bannerService.getBannerList()
+
+            Then("모든 Banner가 조회 된다") {
+                results.size shouldBe 3
+            }
+        }
+
+        When("Banner가 캐싱 되어 있으면") {
+            repeat(5) { bannerService.getBannerList() }
+
+            Then("퀴리가 발생 하지 않는다") {
+                verify(bannerRepository, atMost(1)).findAll()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
@@ -9,10 +9,7 @@ import org.mockito.Mockito.verify
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.TestConstructor
-import org.springframework.test.context.TestConstructor.AutowireMode.ALL
 
-@TestConstructor(autowireMode = ALL)
 @SpringBootTest(webEnvironment = NONE)
 class BannerServiceTest(
     private var bannerService: BannerService,
@@ -29,7 +26,7 @@ class BannerServiceTest(
         )
 
         When("Banner를 전체 조회 하면") {
-            val results = bannerService.getBannerList()
+            val results = bannerService.readAll()
 
             Then("모든 Banner가 조회 된다") {
                 results.size shouldBe 3
@@ -37,7 +34,7 @@ class BannerServiceTest(
         }
 
         When("Banner가 캐싱 되어 있으면") {
-            repeat(5) { bannerService.getBannerList() }
+            repeat(5) { bannerService.readAll() }
 
             Then("퀴리가 발생 하지 않는다") {
                 verify(bannerRepository, atMost(1)).findAll()

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -8,7 +8,7 @@ import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.springframework.http.HttpStatus
 
 class BannerControllerTest(
@@ -36,8 +36,11 @@ class BannerControllerTest(
 
                 Then("배너 목록을 응답한다.") {
                     val findBannerResponse = response.`as`(Array<BannerResponse>::class.java)
-                    assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    assertThat(findBannerResponse.size).isEqualTo(2)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(findBannerResponse.size).isEqualTo(2)
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -27,7 +27,7 @@ class BannerControllerTest(
                 val response = Given {
                     log().all()
                 } When {
-                    get("/banner")
+                    get("/banners")
                 } Then {
                     log().all()
                 } Extract {

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -3,56 +3,43 @@ package com.petqua.presentation.banner
 import com.petqua.application.banner.FindBannerResult
 import com.petqua.domain.banner.Banner
 import com.petqua.domain.banner.BannerRepository
-import com.petqua.test.DataCleaner
-import io.kotest.core.spec.style.BehaviorSpec
-import io.restassured.RestAssured
+import com.petqua.test.ApiTestConfig
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.Assertions.assertThat
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.HttpStatus
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 class BannerControllerTest(
-    @LocalServerPort private val port: Int,
-    private val bannerRepository: BannerRepository,
-    private val dataCleaner: DataCleaner,
-) : BehaviorSpec({
-
-    RestAssured.port = port
-
-    Given("배너가 등록되어 있다.") {
-        val banner = bannerRepository.saveAll(
-            listOf(
-                Banner(imageUrl = "imageUrlC", linkUrl = "linkUrlA"),
-                Banner(imageUrl = "imageUrlB", linkUrl = "linkUrlB")
+    private val bannerRepository: BannerRepository
+) : ApiTestConfig() {
+    init {
+        Given("배너가 등록되어 있다.") {
+            val banner = bannerRepository.saveAll(
+                listOf(
+                    Banner(imageUrl = "imageUrlC", linkUrl = "linkUrlA"),
+                    Banner(imageUrl = "imageUrlB", linkUrl = "linkUrlB")
+                )
             )
-        )
 
-        When("배너 목록을 조회한다.") {
-            val response = Given {
-                log().all()
-            } When {
-                get("/banner")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
+            When("배너 목록을 조회한다.") {
+                val response = Given {
+                    log().all()
+                } When {
+                    get("/banner")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
 
-            Then("배너 목록을 응답한다.") {
-                val findBannerResponse = response.`as`(Array<FindBannerResult>::class.java)
-                assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                assertThat(findBannerResponse.size).isEqualTo(2)
+                Then("배너 목록을 응답한다.") {
+                    val findBannerResponse = response.`as`(Array<FindBannerResult>::class.java)
+                    assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                    assertThat(findBannerResponse.size).isEqualTo(2)
+                }
             }
         }
     }
-
-    afterContainer {
-        dataCleaner.clean()
-    }
-})
+}

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -1,6 +1,6 @@
 package com.petqua.presentation.banner
 
-import com.petqua.application.banner.FindBannerResult
+import com.petqua.application.banner.BannerResponse
 import com.petqua.domain.banner.Banner
 import com.petqua.domain.banner.BannerRepository
 import com.petqua.test.ApiTestConfig
@@ -35,7 +35,7 @@ class BannerControllerTest(
                 }
 
                 Then("배너 목록을 응답한다.") {
-                    val findBannerResponse = response.`as`(Array<FindBannerResult>::class.java)
+                    val findBannerResponse = response.`as`(Array<BannerResponse>::class.java)
                     assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
                     assertThat(findBannerResponse.size).isEqualTo(2)
                 }

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -1,6 +1,6 @@
 package com.petqua.presentation.banner
 
-import com.petqua.application.banner.BannerResponse
+import com.petqua.application.banner.dto.BannerResponse
 import com.petqua.domain.banner.Banner
 import com.petqua.domain.banner.BannerRepository
 import com.petqua.test.ApiTestConfig

--- a/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/banner/BannerControllerTest.kt
@@ -1,0 +1,58 @@
+package com.petqua.presentation.banner
+
+import com.petqua.application.banner.FindBannerResult
+import com.petqua.domain.banner.Banner
+import com.petqua.domain.banner.BannerRepository
+import com.petqua.test.DataCleaner
+import io.kotest.core.spec.style.BehaviorSpec
+import io.restassured.RestAssured
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class BannerControllerTest(
+    @LocalServerPort private val port: Int,
+    private val bannerRepository: BannerRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    RestAssured.port = port
+
+    Given("배너가 등록되어 있다.") {
+        val banner = bannerRepository.saveAll(
+            listOf(
+                Banner(imageUrl = "imageUrlC", linkUrl = "linkUrlA"),
+                Banner(imageUrl = "imageUrlB", linkUrl = "linkUrlB")
+            )
+        )
+
+        When("배너 목록을 조회한다.") {
+            val response = Given {
+                log().all()
+            } When {
+                get("/banner")
+            } Then {
+                log().all()
+            } Extract {
+                response()
+            }
+
+            Then("배너 목록을 응답한다.") {
+                val findBannerResponse = response.`as`(Array<FindBannerResult>::class.java)
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                assertThat(findBannerResponse.size).isEqualTo(2)
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
+++ b/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
@@ -1,0 +1,24 @@
+package com.petqua.test
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.restassured.RestAssured
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+abstract class ApiTestConfig : BehaviorSpec() {
+
+    @LocalServerPort
+    protected val port: Int = RestAssured.port
+
+    @Autowired
+    private lateinit var dataCleaner: DataCleaner
+
+    init {
+        afterContainer {
+            dataCleaner.clean()
+        }
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- closed #16 

### 📁 작업 설명
- 홈 화면에서 사용 배너 정보를 제공하는 API 개발
- `Spring Cache`를 통해 배너 정보 caching

- 워크플로우 수정
    - CI의 경우 push하는 경우에만 수행되도록 변경하였습니다. 보통 push -> PR을 생성하니깐 동일한 작업이 2번 돌더라고요.
    - CD의 경우 docker image가 삭제 되지 않는 현상이 발견되어서 image를 지우는 option을 추가하였습니다.
    - 배포시 table이 생성되어 있지 않아 임시로 `ddl-auto: create`를 추가하였습니다.

### 💻 미완료 태스크
- [x] BaseEntity 적용
- [x] API Test

### 기타
ApiTestConfig를 추가했습니다! [7c74c6b](https://github.com/petqua/backend/pull/18/commits/7c74c6bf1d098f95fe7dc5eacb2551891ba61dbb)

공통으로 설정되는 부분들 (`@SpringBootTest(web ..), dataCleaner, afterContainer)을 공통화 해보았습니다.
BehaviorSpec을 상속하는 구조이다 보니, 추가하기 어려웠는데요. 달라진 점은 아래와 같습니다!

AS-IS
```kotlin
@SpringBootTest(webEnvironment = RANDOM_PORT)
class BannerControllerTest(
    @LocalServerPort private val port: Int,
    private val bannerRepository: BannerRepository,
    private val dataCleaner: DataCleaner,
) : BehaviorSpec({

    RestAssured.port = port

    Given() {
//  ....
    }

    afterContainer {
        dataCleaner.clean()
    }
)}
```

TO-BE
```kotlin
class BannerControllerTest(
    private val bannerRepository: BannerRepository
) : ApiTestConfig() {

    init {
        Given() {
        // ....
       }
   }
}
```

`ApiTestConfig`에서 BehaviorSpec을 상속해서 `init{}` depth가 생겼는데요.
다들 어떠신가요? 의견에 따라 반영해보겠습니다.
쉽게 롤백하기 위해 커밋을 분리해두었어요!