### PR TITLE
feature: DataInitializer 를 통해 dummy data 생성

### DIFF
--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -11,12 +11,14 @@ import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Component
+@Profile("local", "prod")
 class DataInitializer(
     private val announcementRepository: AnnouncementRepository,
     private val bannerRepository: BannerRepository,

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -1,0 +1,116 @@
+package com.petqua.common.config
+
+import com.petqua.domain.announcement.Announcement
+import com.petqua.domain.announcement.AnnouncementRepository
+import com.petqua.domain.banner.Banner
+import com.petqua.domain.banner.BannerRepository
+import com.petqua.domain.product.Product
+import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.recommendation.ProductRecommendation
+import com.petqua.domain.recommendation.ProductRecommendationRepository
+import com.petqua.domain.store.Store
+import com.petqua.domain.store.StoreRepository
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Component
+class DataInitializer(
+    private val announcementRepository: AnnouncementRepository,
+    private val bannerRepository: BannerRepository,
+    private val productRepository: ProductRepository,
+    private val recommendationRepository: ProductRecommendationRepository,
+    private val storeRepository: StoreRepository,
+) {
+
+    @EventListener(ApplicationReadyEvent::class)
+    @Transactional
+    fun init() {
+        // announcement
+        val announcement1 = Announcement(
+            title = "[공지] 펫쿠아 프론트엔드 개발자 구인 중!",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        val announcement2 = Announcement(
+            title = "[공지] 펫쿠아 복지 추가 GPT4 지원 예정",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        val announcement3 = Announcement(
+            title = "[공지] 펫쿠아 개발팀 copilot 적극 활용",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        announcementRepository.saveAll(listOf(announcement1, announcement2, announcement3))
+
+        // banner
+        val banner1 = Banner(
+            imageUrl = "https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        val banner2 = Banner(
+            imageUrl = "https://docs.petqua.co.kr/banners/announcement1.jpg",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        val banner3 = Banner(
+            imageUrl = "https://docs.petqua.co.kr/banners/announcement2.jpg",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        val banner4 = Banner(
+            imageUrl = "https://docs.petqua.co.kr/banners/announcement3.jpg",
+            linkUrl = "https://team.petqua.co.kr/"
+        )
+        bannerRepository.saveAll(listOf(banner1, banner2, banner3, banner4))
+
+        // store
+        val store1 = Store(name = "니모를 찾아서")
+        val store2 = Store(name = "제주 미영이네 식당")
+        storeRepository.saveAll(listOf(store1, store2))
+
+        // product
+        val product1 = Product(
+            name = "니모",
+            category = "기타과",
+            price = BigDecimal.valueOf(30000L).setScale(2),
+            storeId = store1.id,
+            discountRate = 10,
+            discountPrice = BigDecimal(27000L).setScale(2),
+            wishCount = 3,
+            reviewCount = 10,
+            reviewTotalScore = 50,
+            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg",
+            description = "니모를 찾아서 주연"
+        )
+        val product2 = Product(
+            name = "참고등어",
+            category = "대형어",
+            price = BigDecimal.valueOf(20000L).setScale(2),
+            storeId = store1.id,
+            discountRate = 10,
+            discountPrice = BigDecimal(18000L).setScale(2),
+            wishCount = 5,
+            reviewCount = 3,
+            reviewTotalScore = 15,
+            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg",
+            description = "제주산"
+        )
+        val product3 = Product(
+            name = "니모를 찾아서 세트",
+            category = "기타과",
+            price = BigDecimal.valueOf(80000L).setScale(2),
+            storeId = store1.id,
+            discountRate = 50,
+            discountPrice = BigDecimal(40000L).setScale(2),
+            wishCount = 100,
+            reviewCount = 50,
+            reviewTotalScore = 250,
+            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
+            description = "니모를 찾아서 주연 조연"
+        )
+        productRepository.saveAll(listOf(product1, product2, product3))
+
+        // productRecommendation
+        val productRecommendation1 = ProductRecommendation(productId = product3.id)
+        recommendationRepository.saveAll(listOf(productRecommendation1))
+    }
+}

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -29,7 +29,7 @@ class DataInitializer(
 
     @EventListener(ApplicationReadyEvent::class)
     @Transactional
-    fun init() {
+    fun setUpData() {
         // announcement
         val announcement1 = Announcement(
             title = "[공지] 펫쿠아 프론트엔드 개발자 구인 중!",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  profiles:
+    active: "test"
+
+  h2:
+    console:
+      enabled: true
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+
+    hibernate:
+      ddl-auto: create
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.apache.coyote.http11: debug
+    root: info


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #22 

### 📁 작업 설명

- DataInitializer 를 통해 dummy data 생성 로직을 추가했습니다.
- Postman 으로 dummy data 생성 및 조회 로직 테스트 했습니다.

### 📸 작업화면
![image](https://github.com/petqua/backend/assets/106813090/d9246619-7a9d-49be-969e-0443c3eaa047)

### 기타
[참고한 자료](https://engineerinsight.tistory.com/71) 입니다.