### PR TITLE
feature: 봉달목록에 상품 추가 api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
 
+    testImplementation("io.mockk:mockk:1.13.9")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
     testImplementation("io.kotest:kotest-assertions-core:5.4.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,23 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    // kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // spring data jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // spring boot web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    // jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
-    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+
+    // annotation processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     // kotlin jdsl
@@ -37,8 +45,7 @@ dependencies {
 
     // spring boot cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
-
-
+    
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,26 +28,20 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     // kotlin jdsl
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.3.0")
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.3.0")
 
+    // spring boot cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
 
-    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
-
-    // kotlin jdsl
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.3.0")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.3.0")
-
-    implementation("org.springframework.boot:spring-boot-starter-cache")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
 
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
     testImplementation("io.kotest:kotest-assertions-core:5.4.2")

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -16,9 +16,10 @@ class CartProductService(
     private val productRepository: ProductRepository,
 ) {
 
-    fun save(command: SaveCartProductCommand) {
+    fun save(command: SaveCartProductCommand): Long {
 //      TODO  memberRepository.existByIdOrThrow(command.memberId, MemberException(NOT_FOUND_MEMBER))
         productRepository.existByIdOrThrow(command.productId, ProductException(NOT_FOUND_PRODUCT))
-        cartProductRepository.save(command.toCartProduct())
+        val savedCartProduct = cartProductRepository.save(command.toCartProduct())
+        return savedCartProduct.id
     }
 }

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -3,7 +3,10 @@ package com.petqua.application.cart
 import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.common.domain.existByIdOrThrow
 import com.petqua.domain.cart.CartProductRepository
+import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.member.MemberException
+import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import org.springframework.stereotype.Service
@@ -14,10 +17,11 @@ import org.springframework.transaction.annotation.Transactional
 class CartProductService(
     private val cartProductRepository: CartProductRepository,
     private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
 ) {
 
     fun save(command: SaveCartProductCommand): Long {
-//      TODO  memberRepository.existByIdOrThrow(command.memberId, MemberException(NOT_FOUND_MEMBER))
+        memberRepository.existByIdOrThrow(command.memberId, MemberException(NOT_FOUND_MEMBER))
         productRepository.existByIdOrThrow(command.productId, ProductException(NOT_FOUND_PRODUCT))
         val savedCartProduct = cartProductRepository.save(command.toCartProduct())
         return savedCartProduct.id

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -1,0 +1,24 @@
+package com.petqua.application.cart
+
+import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.common.domain.existByIdOrThrow
+import com.petqua.domain.cart.CartProductRepository
+import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.product.ProductException
+import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class CartProductService(
+    private val cartProductRepository: CartProductRepository,
+    private val productRepository: ProductRepository,
+) {
+
+    fun save(command: SaveCartProductCommand) {
+//      TODO  memberRepository.existByIdOrThrow(command.memberId, MemberException(NOT_FOUND_MEMBER))
+        productRepository.existByIdOrThrow(command.productId, ProductException(NOT_FOUND_PRODUCT))
+        cartProductRepository.save(command.toCartProduct())
+    }
+}

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -30,7 +30,7 @@ class CartProductService(
     }
 
     private fun validateDuplicatedProduct(command: SaveCartProductCommand) {
-        cartProductRepository.findByMemberIdAndProductIdAndMaleAndDeliveryMethod(
+        cartProductRepository.findByMemberIdAndProductIdAndIsMaleAndDeliveryMethod(
             memberId = command.memberId,
             productId = command.productId,
             isMale = command.isMale,

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -1,0 +1,22 @@
+package com.petqua.application.cart.dto
+
+import com.petqua.domain.cart.CartProduct
+import com.petqua.domain.cart.DeliveryMethod
+
+data class SaveCartProductCommand(
+    val memberId: Long,
+    val productId: Long,
+    val quantity: Int,
+    val isMale: Boolean,
+    val deliveryMethod: DeliveryMethod,
+) {
+    fun toCartProduct(): CartProduct {
+        return CartProduct(
+            memberId = memberId,
+            productId = productId,
+            quantity = quantity,
+            isMale = isMale,
+            deliveryMethod = deliveryMethod,
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -1,6 +1,7 @@
 package com.petqua.application.cart.dto
 
 import com.petqua.domain.cart.CartProduct
+import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
 
 data class SaveCartProductCommand(
@@ -14,7 +15,7 @@ data class SaveCartProductCommand(
         return CartProduct(
             memberId = memberId,
             productId = productId,
-            quantity = quantity,
+            quantity = CartProductQuantity(quantity),
             isMale = isMale,
             deliveryMethod = deliveryMethod,
         )

--- a/src/main/kotlin/com/petqua/common/domain/Repository.kt
+++ b/src/main/kotlin/com/petqua/common/domain/Repository.kt
@@ -6,3 +6,9 @@ import org.springframework.data.repository.findByIdOrNull
 inline fun <reified T, ID> CrudRepository<T, ID>.findByIdOrThrow(
     id: ID, e: Exception = IllegalArgumentException("${T::class.java.name} entity 를 찾을 수 없습니다. id=$id")
 ): T = findByIdOrNull(id) ?: throw e
+
+
+inline fun <reified T, ID> CrudRepository<T, ID>.existByIdOrThrow(
+    id: ID,
+    e: Exception = IllegalArgumentException("${T::class.java.name} entity 를 찾을 수 없습니다. id=$id")
+): Unit = if (!existsById(id!!)) throw e else Unit

--- a/src/main/kotlin/com/petqua/common/util/Validate.kt
+++ b/src/main/kotlin/com/petqua/common/util/Validate.kt
@@ -1,0 +1,5 @@
+package com.petqua.common.util
+
+inline fun throwExceptionWhen(condition: Boolean, exceptionSupplier: () -> RuntimeException) {
+    if (condition) throw exceptionSupplier()
+}

--- a/src/main/kotlin/com/petqua/domain/auth/LoginMember.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/LoginMember.kt
@@ -2,14 +2,14 @@ package com.petqua.domain.auth
 
 import com.petqua.domain.auth.token.AccessTokenClaims
 
-class Accessor(
+class LoginMember(
     val memberId: Long,
     val authority: Authority,
 ) {
 
     companion object {
-        fun from(accessTokenClaims: AccessTokenClaims): Accessor {
-            return Accessor(
+        fun from(accessTokenClaims: AccessTokenClaims): LoginMember {
+            return LoginMember(
                 memberId = accessTokenClaims.memberId,
                 authority = accessTokenClaims.authority
             )

--- a/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
@@ -2,6 +2,7 @@ package com.petqua.domain.cart
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -20,8 +21,8 @@ class CartProduct(
     @Column(nullable = false)
     val productId: Long,
 
-    @Column(nullable = false)
-    val quantity: Int = 1,
+    @Embedded
+    val quantity: CartProductQuantity,
 
     @Column(nullable = false)
     val isMale: Boolean,

--- a/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
@@ -1,6 +1,7 @@
 package com.petqua.domain.cart
 
 import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.AttributeOverride
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -22,6 +23,7 @@ class CartProduct(
     val productId: Long,
 
     @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "quantity", nullable = false))
     val quantity: CartProductQuantity,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
@@ -1,0 +1,32 @@
+package com.petqua.domain.cart
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class CartProduct(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    val memberId: Long,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    val quantity: Int = 1,
+
+    @Column(nullable = false)
+    val isMale: Boolean,
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    val deliveryMethod: DeliveryMethod,
+) : BaseEntity()

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -4,7 +4,6 @@ import com.petqua.common.util.throwExceptionWhen
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_UNDER_MINIMUM
-import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 private const val MIN_QUANTITY = 1
@@ -12,7 +11,6 @@ private const val MAX_QUANTITY = 99
 
 @Embeddable
 class CartProductQuantity(
-    @Column(nullable = false)
     val value: Int = 1,
 ) {
 

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -4,6 +4,7 @@ import com.petqua.common.util.throwExceptionWhen
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_UNDER_MINIMUM
+import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 private const val MIN_QUANTITY = 1
@@ -11,7 +12,8 @@ private const val MAX_QUANTITY = 99
 
 @Embeddable
 class CartProductQuantity(
-    val quantity: Int,
+    @Column(nullable = false)
+    val quantity: Int = 1,
 ) {
 
     init {

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -1,0 +1,21 @@
+package com.petqua.domain.cart
+
+import com.petqua.common.util.throwExceptionWhen
+import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
+import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_UNDER_MINIMUM
+import jakarta.persistence.Embeddable
+
+private const val MIN_QUANTITY = 1
+private const val MAX_QUANTITY = 99
+
+@Embeddable
+class CartProductQuantity(
+    val quantity: Int,
+) {
+
+    init {
+        throwExceptionWhen(quantity < MIN_QUANTITY) { CartProductException(PRODUCT_QUANTITY_UNDER_MINIMUM) }
+        throwExceptionWhen(quantity > MAX_QUANTITY) { CartProductException(PRODUCT_QUANTITY_OVER_MAXIMUM) }
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -13,11 +13,11 @@ private const val MAX_QUANTITY = 99
 @Embeddable
 class CartProductQuantity(
     @Column(nullable = false)
-    val quantity: Int = 1,
+    val value: Int = 1,
 ) {
 
     init {
-        throwExceptionWhen(quantity < MIN_QUANTITY) { CartProductException(PRODUCT_QUANTITY_UNDER_MINIMUM) }
-        throwExceptionWhen(quantity > MAX_QUANTITY) { CartProductException(PRODUCT_QUANTITY_OVER_MAXIMUM) }
+        throwExceptionWhen(value < MIN_QUANTITY) { CartProductException(PRODUCT_QUANTITY_UNDER_MINIMUM) }
+        throwExceptionWhen(value > MAX_QUANTITY) { CartProductException(PRODUCT_QUANTITY_OVER_MAXIMUM) }
     }
 }

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface CartProductRepository : JpaRepository<CartProduct, Long> {
 
-    fun findByMemberIdAndProductIdAndMaleAndDeliveryMethod(
+    fun findByMemberIdAndProductIdAndIsMaleAndDeliveryMethod(
         memberId: Long,
         productId: Long,
         isMale: Boolean,

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -2,4 +2,12 @@ package com.petqua.domain.cart
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CartProductRepository : JpaRepository<CartProduct, Long>
+interface CartProductRepository : JpaRepository<CartProduct, Long> {
+
+    fun findByMemberIdAndProductIdAndMaleAndDeliveryMethod(
+        memberId: Long,
+        productId: Long,
+        isMale: Boolean,
+        deliveryMethod: DeliveryMethod
+    ): CartProduct?
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -1,0 +1,5 @@
+package com.petqua.domain.cart
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CartProductRepository : JpaRepository<CartProduct, Long>

--- a/src/main/kotlin/com/petqua/domain/cart/DeliveryMethod.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/DeliveryMethod.kt
@@ -1,0 +1,10 @@
+package com.petqua.domain.cart
+
+enum class DeliveryMethod(
+    val description: String,
+) {
+    
+    COMMON("일반 운송"),
+    SAFETY("안전 운송"),
+    PICK_UP("직접 방문"),
+}

--- a/src/main/kotlin/com/petqua/domain/cart/DeliveryMethod.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/DeliveryMethod.kt
@@ -1,10 +1,22 @@
 package com.petqua.domain.cart
 
+import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.INVALID_DELIVERY_METHOD
+import java.util.Locale.ENGLISH
+
 enum class DeliveryMethod(
     val description: String,
 ) {
-    
+
     COMMON("일반 운송"),
     SAFETY("안전 운송"),
     PICK_UP("직접 방문"),
+    ;
+    
+    companion object {
+        fun from(name: String): DeliveryMethod {
+            return enumValues<DeliveryMethod>().find { it.name == name.uppercase(ENGLISH) }
+                ?: throw CartProductException(INVALID_DELIVERY_METHOD)
+        }
+    }
 }

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductException.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductException.kt
@@ -1,0 +1,13 @@
+package com.petqua.exception.cart
+
+import com.petqua.common.exception.BaseException
+import com.petqua.common.exception.BaseExceptionType
+
+class CartProductException(
+    private val exceptionType: CartProductExceptionType,
+) : BaseException() {
+
+    override fun exceptionType(): BaseExceptionType {
+        return exceptionType
+    }
+}

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -2,14 +2,14 @@ package com.petqua.exception.cart
 
 import com.petqua.common.exception.BaseExceptionType
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.BAD_REQUEST
 
 enum class CartProductExceptionType(
     private val httpStatus: HttpStatus,
     private val errorMessage: String,
 ) : BaseExceptionType {
 
-    INVALID_DELIVERY_METHOD(httpStatus = NOT_FOUND, errorMessage = "유효하지 않는 배송 방법입니다.")
+    INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, errorMessage = "유효하지 않는 배송 방법입니다.")
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -12,6 +12,7 @@ enum class CartProductExceptionType(
     INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, errorMessage = "유효하지 않는 배송 방법입니다."),
     PRODUCT_QUANTITY_UNDER_MINIMUM(httpStatus = BAD_REQUEST, errorMessage = "최소 1개 이상의 상품을 담을 수 있습니다."),
     PRODUCT_QUANTITY_OVER_MAXIMUM(httpStatus = BAD_REQUEST, errorMessage = "최대 99개까지 구매할 수 있습니다."),
+    DUPLICATED_PRODUCT(httpStatus = BAD_REQUEST, errorMessage = "이미 장바구니에 담긴 상품입니다.")
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -9,7 +9,9 @@ enum class CartProductExceptionType(
     private val errorMessage: String,
 ) : BaseExceptionType {
 
-    INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, errorMessage = "유효하지 않는 배송 방법입니다.")
+    INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, errorMessage = "유효하지 않는 배송 방법입니다."),
+    PRODUCT_QUANTITY_UNDER_MINIMUM(httpStatus = BAD_REQUEST, errorMessage = "최소 1개 이상의 상품을 담을 수 있습니다."),
+    PRODUCT_QUANTITY_OVER_MAXIMUM(httpStatus = BAD_REQUEST, errorMessage = "최대 99개까지 구매할 수 있습니다."),
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -1,0 +1,22 @@
+package com.petqua.exception.cart
+
+import com.petqua.common.exception.BaseExceptionType
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+
+enum class CartProductExceptionType(
+    private val httpStatus: HttpStatus,
+    private val errorMessage: String,
+) : BaseExceptionType {
+
+    INVALID_DELIVERY_METHOD(httpStatus = NOT_FOUND, errorMessage = "유효하지 않는 배송 방법입니다.")
+    ;
+
+    override fun httpStatus(): HttpStatus {
+        return httpStatus
+    }
+
+    override fun errorMessage(): String {
+        return errorMessage
+    }
+}

--- a/src/main/kotlin/com/petqua/exception/member/MemberException.kt
+++ b/src/main/kotlin/com/petqua/exception/member/MemberException.kt
@@ -1,0 +1,13 @@
+package com.petqua.exception.member
+
+import com.petqua.common.exception.BaseException
+import com.petqua.common.exception.BaseExceptionType
+
+class MemberException(
+    private val exceptionType: MemberExceptionType,
+) : BaseException() {
+
+    override fun exceptionType(): BaseExceptionType {
+        return exceptionType
+    }
+}

--- a/src/main/kotlin/com/petqua/exception/member/MemberExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/member/MemberExceptionType.kt
@@ -1,0 +1,22 @@
+package com.petqua.exception.member
+
+import com.petqua.common.exception.BaseExceptionType
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+
+enum class MemberExceptionType(
+    private val httpStatus: HttpStatus,
+    private val errorMessage: String,
+) : BaseExceptionType {
+
+    NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 회원입니다."),
+    ;
+
+    override fun httpStatus(): HttpStatus {
+        return httpStatus
+    }
+
+    override fun errorMessage(): String {
+        return errorMessage
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/auth/LoginArgumentResolver.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/LoginArgumentResolver.kt
@@ -2,8 +2,8 @@ package com.petqua.presentation.auth
 
 import com.petqua.common.exception.auth.AuthException
 import com.petqua.common.exception.auth.AuthExceptionType
-import com.petqua.domain.auth.Accessor
 import com.petqua.domain.auth.Auth
+import com.petqua.domain.auth.LoginMember
 import com.petqua.domain.auth.token.AuthTokenProvider
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import jakarta.servlet.http.HttpServletRequest
@@ -25,7 +25,7 @@ class LoginArgumentResolver(
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(Auth::class.java)
-                && parameter.getParameterType() == Accessor::class.java
+                && parameter.getParameterType() == LoginMember::class.java
     }
 
     override fun resolveArgument(
@@ -33,20 +33,20 @@ class LoginArgumentResolver(
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): Accessor {
+    ): LoginMember {
         val request = webRequest.getNativeRequest(HttpServletRequest::class.java)
             ?: throw AuthException(AuthExceptionType.INVALID_REQUEST)
-        val refreshToken = request.cookies?.find {it.name == REFRESH_TOKEN_COOKIE}?.value
+        val refreshToken = request.cookies?.find { it.name == REFRESH_TOKEN_COOKIE }?.value
         val accessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION) as String
         val accessTokenClaims = authTokenProvider.getAccessTokenClaims(accessToken)
         if (refreshToken == null) {
-            return Accessor.from(accessTokenClaims)
+            return LoginMember.from(accessTokenClaims)
         }
 
         val savedRefreshToken = refreshTokenRepository.findByMemberId(accessTokenClaims.memberId)
             ?: throw AuthException(AuthExceptionType.INVALID_REFRESH_TOKEN)
         if (savedRefreshToken.token == refreshToken) {
-            return Accessor.from(accessTokenClaims)
+            return LoginMember.from(accessTokenClaims)
         }
         throw AuthException(AuthExceptionType.INVALID_REFRESH_TOKEN)
     }

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -1,0 +1,34 @@
+package com.petqua.presentation.cart
+
+import com.petqua.application.cart.CartProductService
+import com.petqua.application.product.dto.ProductDetailResponse
+import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
+@RequestMapping("/carts")
+@RestController
+class CartProductController(
+    private val cartProductService: CartProductService,
+) {
+
+    @PostMapping
+    fun save(
+//        @AuthMember member: Long, TODO: AuthMember
+        @RequestHeader("X-MEMBER-ID") memberId: Long,
+        @RequestBody request: SaveCartProductRequest
+    ): ResponseEntity<ProductDetailResponse> {
+        val command = request.toCommand(memberId)
+        val cartProductId = cartProductService.save(command)
+        val location = ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/items/{id}")
+            .buildAndExpand(cartProductId)
+            .toUri()
+        return ResponseEntity.created(location).build()
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -2,11 +2,12 @@ package com.petqua.presentation.cart
 
 import com.petqua.application.cart.CartProductService
 import com.petqua.application.product.dto.ProductDetailResponse
+import com.petqua.domain.auth.Accessor
+import com.petqua.domain.auth.Auth
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
@@ -19,11 +20,10 @@ class CartProductController(
 
     @PostMapping
     fun save(
-//        @AuthMember member: Long, TODO: AuthMember
-        @RequestHeader("X-MEMBER-ID") memberId: Long,
+        @Auth accessor: Accessor,
         @RequestBody request: SaveCartProductRequest
     ): ResponseEntity<ProductDetailResponse> {
-        val command = request.toCommand(memberId)
+        val command = request.toCommand(accessor.memberId)
         val cartProductId = cartProductService.save(command)
         val location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/items/{id}")

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -2,8 +2,8 @@ package com.petqua.presentation.cart
 
 import com.petqua.application.cart.CartProductService
 import com.petqua.application.product.dto.ProductDetailResponse
-import com.petqua.domain.auth.Accessor
 import com.petqua.domain.auth.Auth
+import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,10 +20,10 @@ class CartProductController(
 
     @PostMapping
     fun save(
-        @Auth accessor: Accessor,
+        @Auth loginMember: LoginMember,
         @RequestBody request: SaveCartProductRequest
     ): ResponseEntity<ProductDetailResponse> {
-        val command = request.toCommand(accessor.memberId)
+        val command = request.toCommand(loginMember.memberId)
         val cartProductId = cartProductService.save(command)
         val location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/items/{id}")

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -16,7 +16,7 @@ data class SaveCartProductRequest(
             productId = productId,
             quantity = quantity,
             isMale = isMale,
-            deliveryMethod = DeliveryMethod.valueOf(deliveryMethod)
+            deliveryMethod = DeliveryMethod.from(deliveryMethod)
         )
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -1,0 +1,22 @@
+package com.petqua.presentation.cart.dto
+
+import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.domain.cart.DeliveryMethod
+
+data class SaveCartProductRequest(
+    val productId: Long,
+    val quantity: Int,
+    val isMale: Boolean,
+    val deliveryMethod: String,
+) {
+
+    fun toCommand(memberId: Long): SaveCartProductCommand {
+        return SaveCartProductCommand(
+            memberId = memberId,
+            productId = productId,
+            quantity = quantity,
+            isMale = isMale,
+            deliveryMethod = DeliveryMethod.valueOf(deliveryMethod)
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -1,4 +1,4 @@
-package com.petqua.presentation
+package com.petqua.presentation.product
 
 import com.petqua.application.product.ProductService
 import com.petqua.application.product.dto.ProductDetailResponse

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -5,6 +5,7 @@ import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.cart.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
@@ -92,7 +93,7 @@ class CartProductServiceTest(
             )
             cartProductService.save(command)
             Then("예외가 발생 한다") {
-                shouldThrow<MemberException> {
+                shouldThrow<CartProductException> {
                     cartProductService.save(command)
                 }.exceptionType() shouldBe DUPLICATED_PRODUCT
             }

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -1,0 +1,44 @@
+package com.petqua.application.cart
+
+import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.domain.cart.CartProductRepository
+import com.petqua.domain.cart.DeliveryMethod
+import com.petqua.domain.product.ProductRepository
+import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.product
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class CartProductServiceTest(
+    private val cartProductService: CartProductService,
+    private val cartProductRepository: CartProductRepository,
+    private val productRepository: ProductRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    Given("봉달 상품 저장 명령으로") {
+        val productId = productRepository.save(product(id = 1L)).id
+        val memberId = 1L
+        val command = SaveCartProductCommand(
+            memberId = memberId,
+            productId = productId,
+            quantity = 1,
+            isMale = true,
+            deliveryMethod = DeliveryMethod.COMMON,
+        )
+
+        When("봉달 상품을") {
+            cartProductService.save(command)
+
+            Then("저장할 수 있다") {
+                cartProductRepository.findAll().size shouldBe 1
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -5,9 +5,15 @@ import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.cart.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
+import com.petqua.exception.member.MemberException
+import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
+import com.petqua.exception.product.ProductException
+import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.test.DataCleaner
 import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -38,6 +44,57 @@ class CartProductServiceTest(
 
             Then("저장할 수 있다") {
                 cartProductRepository.findAll().size shouldBe 1
+            }
+        }
+    }
+
+    Given("봉달 상품 저장시") {
+        val productId = productRepository.save(product(id = 1L)).id
+        val memberId = memberRepository.save(member(id = 1L)).id
+
+        When("존재 하지 않는 회원이 요청 하는 경우") {
+            val command = SaveCartProductCommand(
+                memberId = 999L,
+                productId = productId,
+                quantity = 1,
+                isMale = true,
+                deliveryMethod = DeliveryMethod.COMMON,
+            )
+            Then("예외가 발생 한다") {
+                shouldThrow<MemberException> {
+                    cartProductService.save(command)
+                }.exceptionType() shouldBe NOT_FOUND_MEMBER
+            }
+        }
+
+        When("존재 하지 않는 상품이 요청 하는 경우") {
+            val command = SaveCartProductCommand(
+                memberId = memberId,
+                productId = 999L,
+                quantity = 1,
+                isMale = true,
+                deliveryMethod = DeliveryMethod.COMMON,
+            )
+            Then("예외가 발생 한다") {
+                shouldThrow<ProductException> {
+                    cartProductService.save(command)
+                }.exceptionType() shouldBe NOT_FOUND_PRODUCT
+            }
+        }
+
+        When("중복 상품이 요청 하는 경우") {
+            val command = SaveCartProductCommand(
+                memberId = memberId,
+                productId = productId,
+                quantity = 1,
+                isMale = true,
+                deliveryMethod = DeliveryMethod.COMMON,
+            )
+            cartProductService.save(command)
+            Then("예외가 발생 한다") {
+                shouldThrow<MemberException> {
+                    cartProductService.save(command)
+                }.exceptionType() shouldBe DUPLICATED_PRODUCT
             }
         }
     }

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -3,8 +3,10 @@ package com.petqua.application.cart
 import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.cart.DeliveryMethod
+import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -16,12 +18,13 @@ class CartProductServiceTest(
     private val cartProductService: CartProductService,
     private val cartProductRepository: CartProductRepository,
     private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
     Given("봉달 상품 저장 명령으로") {
         val productId = productRepository.save(product(id = 1L)).id
-        val memberId = 1L
+        val memberId = memberRepository.save(member(id = 1L)).id
         val command = SaveCartProductCommand(
             memberId = memberId,
             productId = productId,

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -9,8 +9,9 @@ import com.petqua.test.fixture.product
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 class CartProductServiceTest(
     private val cartProductService: CartProductService,
     private val cartProductRepository: CartProductRepository,

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -14,8 +14,9 @@ import com.petqua.test.fixture.store
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class ProductServiceTest(
     private val productService: ProductService,
     private val productRepository: ProductRepository,

--- a/src/test/kotlin/com/petqua/domain/cart/CartProductQuantityTest.kt
+++ b/src/test/kotlin/com/petqua/domain/cart/CartProductQuantityTest.kt
@@ -10,7 +10,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 class CartProductQuantityTest : StringSpec({
     "상품 수량 값객체 생성" {
         val quantity = CartProductQuantity(5)
-        assertThat(quantity.quantity).isEqualTo(5)
+        assertThat(quantity.value).isEqualTo(5)
     }
 
     "최소 수량 미만인 경우 생성 실패" {

--- a/src/test/kotlin/com/petqua/domain/cart/CartProductQuantityTest.kt
+++ b/src/test/kotlin/com/petqua/domain/cart/CartProductQuantityTest.kt
@@ -1,0 +1,31 @@
+package com.petqua.domain.cart
+
+import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
+import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_UNDER_MINIMUM
+import io.kotest.core.spec.style.StringSpec
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+
+class CartProductQuantityTest : StringSpec({
+    "상품 수량 값객체 생성" {
+        val quantity = CartProductQuantity(5)
+        assertThat(quantity.quantity).isEqualTo(5)
+    }
+
+    "최소 수량 미만인 경우 생성 실패" {
+        assertThatThrownBy {
+            CartProductQuantity(0)
+        }.isInstanceOf(CartProductException::class.java)
+            .extracting("exceptionType")
+            .isEqualTo(PRODUCT_QUANTITY_UNDER_MINIMUM)
+    }
+
+    "최대 수량 초과인 경우 생성 실패" {
+        assertThatThrownBy {
+            CartProductQuantity(100)
+        }.isInstanceOf(CartProductException::class.java)
+            .extracting("exceptionType")
+            .isEqualTo(PRODUCT_QUANTITY_OVER_MAXIMUM)
+    }
+})

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -1,6 +1,5 @@
-package com.petqua.domain
+package com.petqua.domain.product
 
-import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.ProductSourceType.HOME_RECOMMENDED
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.Sorter.REVIEW_COUNT_DESC
@@ -19,10 +18,10 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal.ONE
 import java.math.BigDecimal.TEN
 import java.math.BigDecimal.ZERO
+import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class ProductCustomRepositoryImplTest(

--- a/src/test/kotlin/com/petqua/domain/product/ProductTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductTest.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain
+package com.petqua.domain.product
 
 import com.petqua.test.fixture.product
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -1,0 +1,53 @@
+package com.petqua.presentation.cart
+
+import com.petqua.domain.product.ProductRepository
+import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import com.petqua.test.ApiTestConfig
+import com.petqua.test.fixture.product
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+
+private const val AUTHORIZATION_HEADER = "X-MEMBER-ID" // FIXME: 인가 구현 완료 후 변경 예정
+
+class CartProductControllerTest(
+    private val productRepository: ProductRepository
+) : ApiTestConfig() {
+    init {
+        val savedProduct = productRepository.save(product(id = 1L))
+        Given("봉달에 상품 저장을") {
+            val request = SaveCartProductRequest(
+                productId = savedProduct.id,
+                quantity = 1,
+                isMale = true,
+                deliveryMethod = "SAFETY"
+            )
+            When("요청 하면") {
+                val response = Given {
+                    log().all()
+                        .body(request)
+                        .header(AUTHORIZATION_HEADER, 1L)
+                        .contentType("application/json")
+                } When {
+                    post("/carts")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("배너 목록을 응답한다.") {
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED.value())
+                        it.assertThat(response.header(HttpHeaders.LOCATION)).contains("/carts/items")
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -13,14 +13,14 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.HttpStatus
-
-private const val AUTHORIZATION_HEADER = "X-MEMBER-ID" // FIXME: 인가 구현 완료 후 변경 예정
 
 class CartProductControllerTest(
     private val productRepository: ProductRepository
 ) : ApiTestConfig() {
     init {
+        val memberAuthResponse = signInAsMember()
         val savedProduct = productRepository.save(product(id = 1L))
         Given("봉달에 상품 저장을") {
             val request = SaveCartProductRequest(
@@ -33,7 +33,7 @@ class CartProductControllerTest(
                 val response = Given {
                     log().all()
                         .body(request)
-                        .header(AUTHORIZATION_HEADER, 1L)
+                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
                         .contentType("application/json")
                 } When {
                     post("/carts")
@@ -63,7 +63,7 @@ class CartProductControllerTest(
                 val response = Given {
                     log().all()
                         .body(request)
-                        .header(AUTHORIZATION_HEADER, 1L)
+                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
                         .contentType("application/json")
                 } When {
                     post("/carts")
@@ -92,7 +92,7 @@ class CartProductControllerTest(
                 val response = Given {
                     log().all()
                         .body(request)
-                        .header(AUTHORIZATION_HEADER, 1L)
+                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
                         .contentType("application/json")
                 } When {
                     post("/carts")

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -1,6 +1,9 @@
 package com.petqua.presentation.cart
 
+import com.petqua.common.exception.ExceptionResponse
 import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.cart.CartProductExceptionType.INVALID_DELIVERY_METHOD
+import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
@@ -44,7 +47,66 @@ class CartProductControllerTest(
                     assertSoftly {
                         it.assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED.value())
                         it.assertThat(response.header(HttpHeaders.LOCATION)).contains("/carts/items")
+                    }
+                }
+            }
+        }
 
+        Given("봉달에 상품 저장 요청시") {
+            When("지원하지 않는 배송 방식으로 요청 하면") {
+                val request = SaveCartProductRequest(
+                    productId = savedProduct.id,
+                    quantity = 1,
+                    isMale = true,
+                    deliveryMethod = "NOT_SUPPORTED"
+                )
+                val response = Given {
+                    log().all()
+                        .body(request)
+                        .header(AUTHORIZATION_HEADER, 1L)
+                        .contentType("application/json")
+                } When {
+                    post("/carts")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value())
+                        it.assertThat(errorResponse.message).isEqualTo(INVALID_DELIVERY_METHOD.errorMessage())
+                    }
+                }
+            }
+
+            When("존재 하지 않는 상품 저장을 요청 하면") {
+                val request = SaveCartProductRequest(
+                    productId = 999L,
+                    quantity = 1,
+                    isMale = true,
+                    deliveryMethod = "SAFETY"
+                )
+                val response = Given {
+                    log().all()
+                        .body(request)
+                        .header(AUTHORIZATION_HEADER, 1L)
+                        .contentType("application/json")
+                } When {
+                    post("/carts")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND.value())
+                        it.assertThat(errorResponse.message).isEqualTo(NOT_FOUND_PRODUCT.errorMessage())
                     }
                 }
             }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -43,7 +43,7 @@ class CartProductControllerTest(
                     response()
                 }
 
-                Then("배너 목록을 응답한다.") {
+                Then("봉달 목록에 상품이 저장된다") {
                     assertSoftly {
                         it.assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED.value())
                         it.assertThat(response.header(HttpHeaders.LOCATION)).contains("/carts/items")

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -140,6 +140,7 @@ class CartProductControllerTest(
                     }
                 }
             }
+//            TODO When("중복 상품을 담으면") {
         }
     }
 }

--- a/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
+++ b/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
@@ -1,12 +1,21 @@
 package com.petqua.test
 
+import com.petqua.application.auth.AuthResponse
+import com.petqua.test.config.OauthTestConfig
 import io.kotest.core.spec.style.BehaviorSpec
 import io.restassured.RestAssured
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.restassured.response.Response
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Import
 
+@Import(OauthTestConfig::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 abstract class ApiTestConfig : BehaviorSpec() {
 
@@ -23,6 +32,24 @@ abstract class ApiTestConfig : BehaviorSpec() {
 
         afterContainer {
             dataCleaner.clean()
+        }
+    }
+
+    final fun signInAsMember(): AuthResponse {
+        val response = requestSignIn()
+        return response.`as`(AuthResponse::class.java)
+    }
+
+    private fun requestSignIn(): Response {
+        return Given {
+            log().all()
+                .queryParam("code", "code")
+        } When {
+            get("/oauth/login/{oauthServerType}", "kakao")
+        } Then {
+            log().all()
+        } Extract {
+            response()
         }
     }
 }

--- a/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
@@ -1,0 +1,18 @@
+package com.petqua.test.fixture
+
+import com.petqua.domain.auth.Authority
+import com.petqua.domain.member.Member
+
+fun member(
+    id: Long = 1L,
+    oauthId: String = "oauthId",
+    oauthServerNumber: Int = 1,
+    authority: Authority = Authority.MEMBER
+): Member {
+    return Member(
+        id,
+        oauthId,
+        oauthServerNumber,
+        authority
+    )
+}


### PR DESCRIPTION
### 📌 관련 이슈
- closed #25 

### 📁 작업 설명

- 설명
- 봉달목록 도메인 추가
```kotlin
@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
val id: Long = 0L,

@Column(nullable = false)
val memberId: Long,

@Column(nullable = false)
val productId: Long,

@Column(nullable = false)
val quantity: Int = 1,

@Column(nullable = false)
val isMale: Boolean,

@Enumerated(value = EnumType.STRING)
@Column(nullable = false)
val deliveryMethod: DeliveryMethod,
```
상품의 옵션이 `수량/암수구분/운송 방식`만 선택 가능하다고 생각하고 구현하였습니다.
추후 옵션이 추가 된다면  product_option을 테이블로 분리하고, product_option_id를 가지는 방식으로 수정할 생각입니다.

- 상품을 정해진 옵션에 따라 봉달 목록에 추가하는 API 구현

### 기타
- `existByIdOrThrow`라는 확장함수 하나 추가했습니다. 042708bab1c302c1b1e5aea0e4c358a99a74b578
반환 값이 없는 검증용으로 사용 할 목적으로 만들었어요!

- ControllerTest에서 자주 사용될 로그인셋업 메서드를 추가하였습니다.
d942e40a7e824480df6204c2d37136f2c0e4b671
공통으로 사용되는 `ApiTestConfig`에 추가 하였는데, 다들 괜찮은지 궁금합니다! (여진님이 만들어두신 FakeKakaoClient 사용 하였습니다)