### PR TITLE
feature: 봉달 목록내 상품 수정 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -9,7 +9,6 @@ import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
-import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -1,12 +1,16 @@
 package com.petqua.application.cart
 
 import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.common.domain.existByIdOrThrow
+import com.petqua.common.domain.findByIdOrThrow
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
+import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import com.petqua.exception.product.ProductException
@@ -36,5 +40,14 @@ class CartProductService(
             isMale = command.isMale,
             deliveryMethod = command.deliveryMethod
         )?.also { throw CartProductException(DUPLICATED_PRODUCT) }
+    }
+
+    fun updateOptions(command: UpdateCartProductOptionCommand) {
+        val cartProduct = cartProductRepository.findByIdOrThrow(
+            command.cartProductId,
+            CartProductException(NOT_FOUND_CART_PRODUCT)
+        )
+        cartProduct.validateOwner(command.memberId)
+        cartProduct.updateOptions(command.quantity, command.isMale, command.deliveryMethod)
     }
 }

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -21,3 +21,12 @@ data class SaveCartProductCommand(
         )
     }
 }
+
+
+data class UpdateCartProductOptionCommand(
+    val memberId: Long,
+    val cartProductId: Long,
+    val quantity: CartProductQuantity,
+    val isMale: Boolean,
+    val deliveryMethod: DeliveryMethod,
+)

--- a/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
@@ -2,6 +2,9 @@ package com.petqua.domain.cart
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.AttributeOverride
+import com.petqua.common.util.throwExceptionWhen
+import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.FORBIDDEN_CART_PRODUCT
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -24,12 +27,27 @@ class CartProduct(
 
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "quantity", nullable = false))
-    val quantity: CartProductQuantity,
+    var quantity: CartProductQuantity,
 
     @Column(nullable = false)
-    val isMale: Boolean,
+    var isMale: Boolean,
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
-    val deliveryMethod: DeliveryMethod,
-) : BaseEntity()
+    var deliveryMethod: DeliveryMethod,
+) : BaseEntity() {
+
+    fun validateOwner(accessMemberId: Long) {
+        throwExceptionWhen(accessMemberId != this.memberId) { CartProductException(FORBIDDEN_CART_PRODUCT) }
+    }
+
+    fun updateOptions(
+        quantity: CartProductQuantity,
+        isMale: Boolean,
+        deliveryMethod: DeliveryMethod,
+    ) {
+        this.quantity = quantity
+        this.isMale = isMale
+        this.deliveryMethod = deliveryMethod
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -25,10 +25,10 @@ class CartProductQuantity(
 
         other as CartProductQuantity
 
-        return quantity == other.quantity
+        return value == other.value
     }
 
     override fun hashCode(): Int {
-        return quantity
+        return value
     }
 }

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductQuantity.kt
@@ -18,4 +18,17 @@ class CartProductQuantity(
         throwExceptionWhen(value < MIN_QUANTITY) { CartProductException(PRODUCT_QUANTITY_UNDER_MINIMUM) }
         throwExceptionWhen(value > MAX_QUANTITY) { CartProductException(PRODUCT_QUANTITY_OVER_MAXIMUM) }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CartProductQuantity
+
+        return quantity == other.quantity
+    }
+
+    override fun hashCode(): Int {
+        return quantity
+    }
 }

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -3,6 +3,8 @@ package com.petqua.exception.cart
 import com.petqua.common.exception.BaseExceptionType
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.NOT_FOUND
 
 enum class CartProductExceptionType(
     private val httpStatus: HttpStatus,
@@ -12,7 +14,9 @@ enum class CartProductExceptionType(
     INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, errorMessage = "유효하지 않는 배송 방법입니다."),
     PRODUCT_QUANTITY_UNDER_MINIMUM(httpStatus = BAD_REQUEST, errorMessage = "최소 1개 이상의 상품을 담을 수 있습니다."),
     PRODUCT_QUANTITY_OVER_MAXIMUM(httpStatus = BAD_REQUEST, errorMessage = "최대 99개까지 구매할 수 있습니다."),
-    DUPLICATED_PRODUCT(httpStatus = BAD_REQUEST, errorMessage = "이미 장바구니에 담긴 상품입니다.")
+    DUPLICATED_PRODUCT(httpStatus = BAD_REQUEST, errorMessage = "이미 장바구니에 담긴 상품입니다."),
+    NOT_FOUND_CART_PRODUCT(httpStatus = NOT_FOUND, errorMessage = "존재 하지 않는 봉달 상품입니다."),
+    FORBIDDEN_CART_PRODUCT(httpStatus = FORBIDDEN, errorMessage = "해당 봉달 상품에 대한 권한이 없습니다."),
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -35,7 +35,7 @@ class CartProductController(
         return ResponseEntity.created(location).build()
     }
 
-    @PatchMapping("/items/{cartProductId}/options")
+    @PatchMapping("/products/{cartProductId}/options")
     fun updateOptions(
         @Auth loginMember: LoginMember,
         @PathVariable cartProductId: Long,

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -5,7 +5,10 @@ import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -30,5 +33,16 @@ class CartProductController(
             .buildAndExpand(cartProductId)
             .toUri()
         return ResponseEntity.created(location).build()
+    }
+
+    @PatchMapping("/items/{cartProductId}/options")
+    fun updateOptions(
+        @Auth loginMember: LoginMember,
+        @PathVariable cartProductId: Long,
+        @RequestBody request: UpdateCartProductOptionRequest
+    ): ResponseEntity<Void> {
+        val command = request.toCommand(loginMember.memberId, cartProductId)
+        cartProductService.updateOptions(command)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -1,6 +1,8 @@
 package com.petqua.presentation.cart.dto
 
 import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
+import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
 
 data class SaveCartProductRequest(
@@ -15,6 +17,23 @@ data class SaveCartProductRequest(
             memberId = memberId,
             productId = productId,
             quantity = quantity,
+            isMale = isMale,
+            deliveryMethod = DeliveryMethod.from(deliveryMethod)
+        )
+    }
+}
+
+data class UpdateCartProductOptionRequest(
+    val quantity: Int,
+    val isMale: Boolean,
+    val deliveryMethod: String,
+) {
+
+    fun toCommand(memberId: Long, cartProductId: Long): UpdateCartProductOptionCommand {
+        return UpdateCartProductOptionCommand(
+            memberId = memberId,
+            cartProductId = cartProductId,
+            quantity = CartProductQuantity(quantity),
             isMale = isMale,
             deliveryMethod = DeliveryMethod.from(deliveryMethod)
         )

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -1,8 +1,12 @@
 package com.petqua.application.cart
 
 import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
+import com.petqua.common.domain.findByIdOrThrow
+import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.CartProductRepository
-import com.petqua.domain.cart.DeliveryMethod
+import com.petqua.domain.cart.DeliveryMethod.COMMON
+import com.petqua.domain.cart.DeliveryMethod.SAFETY
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.exception.cart.CartProductException
@@ -12,9 +16,11 @@ import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.cartProduct
 import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -37,7 +43,7 @@ class CartProductServiceTest(
             productId = productId,
             quantity = 1,
             isMale = true,
-            deliveryMethod = DeliveryMethod.COMMON,
+            deliveryMethod = COMMON,
         )
 
         When("봉달 상품을") {
@@ -59,7 +65,7 @@ class CartProductServiceTest(
                 productId = productId,
                 quantity = 1,
                 isMale = true,
-                deliveryMethod = DeliveryMethod.COMMON,
+                deliveryMethod = COMMON,
             )
             Then("예외가 발생 한다") {
                 shouldThrow<MemberException> {
@@ -74,7 +80,7 @@ class CartProductServiceTest(
                 productId = 999L,
                 quantity = 1,
                 isMale = true,
-                deliveryMethod = DeliveryMethod.COMMON,
+                deliveryMethod = COMMON,
             )
             Then("예외가 발생 한다") {
                 shouldThrow<ProductException> {
@@ -89,13 +95,46 @@ class CartProductServiceTest(
                 productId = productId,
                 quantity = 1,
                 isMale = true,
-                deliveryMethod = DeliveryMethod.COMMON,
+                deliveryMethod = COMMON,
             )
             cartProductService.save(command)
             Then("예외가 발생 한다") {
                 shouldThrow<CartProductException> {
                     cartProductService.save(command)
                 }.exceptionType() shouldBe DUPLICATED_PRODUCT
+            }
+        }
+    }
+
+    Given("봉달 상품 옵션 수정 명령으로") {
+        val productId = productRepository.save(product(id = 1L)).id
+        val memberId = memberRepository.save(member(id = 1L)).id
+        val cartProduct = cartProductRepository.save(
+            cartProduct(
+                memberId = memberId,
+                productId = productId,
+                deliveryMethod = COMMON
+            )
+        )
+
+        val command = UpdateCartProductOptionCommand(
+            cartProductId = cartProduct.id,
+            memberId = memberId,
+            quantity = CartProductQuantity(2),
+            isMale = false,
+            deliveryMethod = SAFETY,
+        )
+
+        When("봉달 상품 옵션을") {
+            cartProductService.updateOptions(command)
+
+            Then("수정할 수 있다") {
+                val savedCartProduct = cartProductRepository.findByIdOrThrow(cartProduct.id)
+                assertSoftly(savedCartProduct) {
+                    quantity shouldBe CartProductQuantity(2)
+                    isMale shouldBe false
+                    deliveryMethod shouldBe SAFETY
+                }
             }
         }
     }

--- a/src/test/kotlin/com/petqua/domain/auth/FakeKakaoOauthApiClient.kt
+++ b/src/test/kotlin/com/petqua/domain/auth/FakeKakaoOauthApiClient.kt
@@ -5,6 +5,7 @@ import com.petqua.domain.auth.oauth.kakao.KakaoAccount
 import com.petqua.domain.auth.oauth.kakao.KakaoOauthApiClient
 import com.petqua.domain.auth.oauth.kakao.KakaoUserInfo
 import com.petqua.domain.auth.oauth.kakao.Profile
+import java.util.UUID
 import org.springframework.util.MultiValueMap
 
 class FakeKakaoOauthApiClient : KakaoOauthApiClient {
@@ -21,7 +22,7 @@ class FakeKakaoOauthApiClient : KakaoOauthApiClient {
         )
         return KakaoUserInfo(
             kakaoAccount = kakaoAccount,
-            oauthId = "oauthId"
+            oauthId = "oauthId" + UUID.randomUUID().toString()
         )
     }
 }

--- a/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
+++ b/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
@@ -1,0 +1,46 @@
+package com.petqua.domain.cart
+
+import com.petqua.exception.cart.CartProductException
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class CartProductTest : StringSpec({
+
+    "장바구니 상품 수정" {
+        val cartProduct = CartProduct(
+            memberId = 1L,
+            productId = 1L,
+            quantity = CartProductQuantity(5),
+            isMale = true,
+            deliveryMethod = DeliveryMethod.COMMON,
+        )
+
+        cartProduct.updateOptions(
+            quantity = CartProductQuantity(10),
+            isMale = false,
+            deliveryMethod = DeliveryMethod.COMMON,
+        )
+
+        assertSoftly(cartProduct) {
+            isMale shouldBe false
+            quantity.quantity shouldBe 10
+            deliveryMethod shouldBe DeliveryMethod.COMMON
+        }
+    }
+
+    "장바구니 상품 소유자 확인" {
+        val cartProduct = CartProduct(
+            memberId = 1L,
+            productId = 1L,
+            quantity = CartProductQuantity(5),
+            isMale = true,
+            deliveryMethod = DeliveryMethod.COMMON,
+        )
+
+        shouldThrow<CartProductException> {
+            cartProduct.validateOwner(2L)
+        }
+    }
+})

--- a/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
+++ b/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
@@ -25,7 +25,7 @@ class CartProductTest : StringSpec({
 
         assertSoftly(cartProduct) {
             isMale shouldBe false
-            quantity.quantity shouldBe 10
+            quantity.value shouldBe 10
             deliveryMethod shouldBe DeliveryMethod.COMMON
         }
     }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -53,7 +53,7 @@ fun requestUpdateCartProductOption(
             .header(HttpHeaders.AUTHORIZATION, accessToken)
             .contentType("application/json")
     } When {
-        patch("/carts/items/{cartProductId}/options", cartProductId)
+        patch("/carts/products/{cartProductId}/options", cartProductId)
     } Then {
         log().all()
     } Extract {

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -1,0 +1,23 @@
+package com.petqua.presentation.cart
+
+import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.restassured.response.Response
+import org.springframework.http.HttpHeaders
+
+fun requestSaveCartProduct(request: SaveCartProductRequest, accessToken: String): Response =
+    Given {
+        log().all()
+            .body(request)
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .contentType("application/json")
+    } When {
+        post("/carts")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -42,7 +42,6 @@ private fun parseCartProductIdFromLocationHeader(response: Response): Long {
     return response.header(HttpHeaders.LOCATION).split("/").last().toLong()
 }
 
-
 fun requestUpdateCartProductOption(
     cartProductId: Long,
     request: UpdateCartProductOptionRequest,

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -1,6 +1,7 @@
 package com.petqua.presentation.cart
 
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -8,8 +9,11 @@ import io.restassured.module.kotlin.extensions.When
 import io.restassured.response.Response
 import org.springframework.http.HttpHeaders
 
-fun requestSaveCartProduct(request: SaveCartProductRequest, accessToken: String): Response =
-    Given {
+fun requestSaveCartProduct(
+    request: SaveCartProductRequest,
+    accessToken: String
+): Response {
+    return Given {
         log().all()
             .body(request)
             .header(HttpHeaders.AUTHORIZATION, accessToken)
@@ -21,3 +25,39 @@ fun requestSaveCartProduct(request: SaveCartProductRequest, accessToken: String)
     } Extract {
         response()
     }
+}
+
+fun saveCartProductAndReturnId(accessToken: String): Long {
+    val sampleCartProduct = SaveCartProductRequest(
+        productId = 1L,
+        quantity = 1,
+        isMale = true,
+        deliveryMethod = "COMMON"
+    )
+    val response = requestSaveCartProduct(sampleCartProduct, accessToken)
+    return parseCartProductIdFromLocationHeader(response)
+}
+
+private fun parseCartProductIdFromLocationHeader(response: Response): Long {
+    return response.header(HttpHeaders.LOCATION).split("/").last().toLong()
+}
+
+
+fun requestUpdateCartProductOption(
+    cartProductId: Long,
+    request: UpdateCartProductOptionRequest,
+    accessToken: String
+): Response {
+    return Given {
+        log().all()
+            .body(request)
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .contentType("application/json")
+    } When {
+        patch("/carts/items/{cartProductId}/options", cartProductId)
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -6,8 +6,10 @@ import com.petqua.exception.cart.CartProductExceptionType.INVALID_DELIVERY_METHO
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -92,6 +94,28 @@ class CartProductControllerTest(
                 }
             }
 //            TODO When("중복 상품을 담으면") {
+        }
+
+        Given("봉달 상품의 옵션 수정을") {
+            val cartProductId = saveCartProductAndReturnId(memberAuthResponse.accessToken)
+
+            When("요청 하면") {
+                val request = UpdateCartProductOptionRequest(
+                    quantity = 2,
+                    isMale = false,
+                    deliveryMethod = "SAFETY"
+                )
+
+                val response = requestUpdateCartProductOption(
+                    cartProductId,
+                    request,
+                    memberAuthResponse.accessToken
+                )
+
+                Then("봉달 상품의 옵션이 수정된다") {
+                    assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT.value())
+                }
+            }
         }
     }
 }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -2,7 +2,9 @@ package com.petqua.presentation.cart
 
 import com.petqua.common.exception.ExceptionResponse
 import com.petqua.domain.product.ProductRepository
+import com.petqua.exception.cart.CartProductExceptionType.FORBIDDEN_CART_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.INVALID_DELIVERY_METHOD
+import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.PRODUCT_QUANTITY_OVER_MAXIMUM
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
@@ -12,7 +14,11 @@ import com.petqua.test.fixture.product
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.NO_CONTENT
 
 class CartProductControllerTest(
     private val productRepository: ProductRepository,
@@ -32,7 +38,7 @@ class CartProductControllerTest(
 
                 Then("봉달 목록에 상품이 저장된다") {
                     assertSoftly {
-                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED.value())
+                        it.assertThat(response.statusCode).isEqualTo(CREATED.value())
                         it.assertThat(response.header(HttpHeaders.LOCATION)).contains("/carts/items")
                     }
                 }
@@ -52,7 +58,7 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly {
-                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value())
+                        it.assertThat(response.statusCode).isEqualTo(BAD_REQUEST.value())
                         it.assertThat(errorResponse.message).isEqualTo(INVALID_DELIVERY_METHOD.errorMessage())
                     }
                 }
@@ -70,7 +76,7 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly {
-                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND.value())
+                        it.assertThat(response.statusCode).isEqualTo(NOT_FOUND.value())
                         it.assertThat(errorResponse.message).isEqualTo(NOT_FOUND_PRODUCT.errorMessage())
                     }
                 }
@@ -88,7 +94,7 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly {
-                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value())
+                        it.assertThat(response.statusCode).isEqualTo(BAD_REQUEST.value())
                         it.assertThat(errorResponse.message).isEqualTo(PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage())
                     }
                 }
@@ -113,7 +119,100 @@ class CartProductControllerTest(
                 )
 
                 Then("봉달 상품의 옵션이 수정된다") {
-                    assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT.value())
+                    assertThat(response.statusCode).isEqualTo(NO_CONTENT.value())
+                }
+            }
+        }
+
+        Given("봉달 상품의 옵션 수정시") {
+            val cartProductId = saveCartProductAndReturnId(memberAuthResponse.accessToken)
+
+            When("존재하지 않는 봉달 상품 수정을 요청 하면") {
+                val request = UpdateCartProductOptionRequest(
+                    quantity = 2,
+                    isMale = false,
+                    deliveryMethod = "SAFETY"
+                )
+
+                val response = requestUpdateCartProductOption(
+                    999L,
+                    request,
+                    memberAuthResponse.accessToken
+                )
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(NOT_FOUND.value())
+                        it.assertThat(errorResponse.message).isEqualTo(NOT_FOUND_CART_PRODUCT.errorMessage())
+                    }
+                }
+            }
+
+            When("유효하지 않은 상품 수량으로 수정 하면") {
+                val request = UpdateCartProductOptionRequest(
+                    quantity = 1_000,
+                    isMale = false,
+                    deliveryMethod = "SAFETY"
+                )
+
+                val response = requestUpdateCartProductOption(
+                    cartProductId,
+                    request,
+                    memberAuthResponse.accessToken
+                )
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(BAD_REQUEST.value())
+                        it.assertThat(errorResponse.message).isEqualTo(PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage())
+                    }
+                }
+            }
+
+            When("지원하지 않는 배송 방식으로 수정 하면") {
+                val request = UpdateCartProductOptionRequest(
+                    quantity = 2,
+                    isMale = false,
+                    deliveryMethod = "NOT_SUPPORTED"
+                )
+
+                val response = requestUpdateCartProductOption(
+                    cartProductId,
+                    request,
+                    memberAuthResponse.accessToken
+                )
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(BAD_REQUEST.value())
+                        it.assertThat(errorResponse.message).isEqualTo(INVALID_DELIVERY_METHOD.errorMessage())
+                    }
+                }
+            }
+
+            When("다른 회원의 상품을 수정 하면") {
+                val otherMemberResponse = signInAsMember()
+                val request = UpdateCartProductOptionRequest(
+                    quantity = 2,
+                    isMale = false,
+                    deliveryMethod = "SAFETY"
+                )
+
+                val response = requestUpdateCartProductOption(
+                    cartProductId,
+                    request,
+                    otherMemberResponse.accessToken
+                )
+
+                Then("예외가 발생한다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(FORBIDDEN.value())
+                        it.assertThat(errorResponse.message).isEqualTo(FORBIDDEN_CART_PRODUCT.errorMessage())
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -25,9 +25,9 @@ class CartProductControllerTest(
     private val productRepository: ProductRepository,
 ) : ApiTestConfig() {
     init {
-        val memberAuthResponse = signInAsMember()
-        val savedProduct = productRepository.save(product(id = 1L))
         Given("봉달에 상품 저장을") {
+            val memberAuthResponse = signInAsMember()
+            val savedProduct = productRepository.save(product(id = 1L))
             val request = SaveCartProductRequest(
                 productId = savedProduct.id,
                 quantity = 1,
@@ -47,6 +47,8 @@ class CartProductControllerTest(
         }
 
         Given("봉달에 상품 저장 요청시") {
+            val memberAuthResponse = signInAsMember()
+            val savedProduct = productRepository.save(product(id = 1L))
             When("지원하지 않는 배송 방식으로 요청 하면") {
                 val invalidDeliveryMethodRequest = SaveCartProductRequest(
                     productId = savedProduct.id,
@@ -123,6 +125,8 @@ class CartProductControllerTest(
         }
 
         Given("봉달 상품의 옵션 수정을") {
+            productRepository.save(product(id = 1L))
+            val memberAuthResponse = signInAsMember()
             val cartProductId = saveCartProductAndReturnId(memberAuthResponse.accessToken)
 
             When("요청 하면") {
@@ -145,6 +149,8 @@ class CartProductControllerTest(
         }
 
         Given("봉달 상품의 옵션 수정시") {
+            val savedProduct = productRepository.save(product(id = 1L))
+            val memberAuthResponse = signInAsMember()
             val cartProductId = saveCartProductAndReturnId(memberAuthResponse.accessToken)
 
             When("존재하지 않는 봉달 상품 수정을 요청 하면") {

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -8,17 +8,12 @@ import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
-import io.restassured.module.kotlin.extensions.Extract
-import io.restassured.module.kotlin.extensions.Given
-import io.restassured.module.kotlin.extensions.Then
-import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.HttpStatus
 
 class CartProductControllerTest(
-    private val productRepository: ProductRepository
+    private val productRepository: ProductRepository,
 ) : ApiTestConfig() {
     init {
         val memberAuthResponse = signInAsMember()
@@ -31,18 +26,7 @@ class CartProductControllerTest(
                 deliveryMethod = "SAFETY"
             )
             When("요청 하면") {
-                val response = Given {
-                    log().all()
-                        .body(request)
-                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
-                        .contentType("application/json")
-                } When {
-                    post("/carts")
-                } Then {
-                    log().all()
-                } Extract {
-                    response()
-                }
+                val response = requestSaveCartProduct(request, memberAuthResponse.accessToken)
 
                 Then("봉달 목록에 상품이 저장된다") {
                     assertSoftly {
@@ -55,24 +39,13 @@ class CartProductControllerTest(
 
         Given("봉달에 상품 저장 요청시") {
             When("지원하지 않는 배송 방식으로 요청 하면") {
-                val request = SaveCartProductRequest(
+                val invalidDeliveryMethodRequest = SaveCartProductRequest(
                     productId = savedProduct.id,
                     quantity = 1,
                     isMale = true,
                     deliveryMethod = "NOT_SUPPORTED"
                 )
-                val response = Given {
-                    log().all()
-                        .body(request)
-                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
-                        .contentType("application/json")
-                } When {
-                    post("/carts")
-                } Then {
-                    log().all()
-                } Extract {
-                    response()
-                }
+                val response = requestSaveCartProduct(invalidDeliveryMethodRequest, memberAuthResponse.accessToken)
 
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
@@ -84,24 +57,13 @@ class CartProductControllerTest(
             }
 
             When("존재 하지 않는 상품 저장을 요청 하면") {
-                val request = SaveCartProductRequest(
+                val notExistProductRequest = SaveCartProductRequest(
                     productId = 999L,
                     quantity = 1,
                     isMale = true,
                     deliveryMethod = "SAFETY"
                 )
-                val response = Given {
-                    log().all()
-                        .body(request)
-                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
-                        .contentType("application/json")
-                } When {
-                    post("/carts")
-                } Then {
-                    log().all()
-                } Extract {
-                    response()
-                }
+                val response = requestSaveCartProduct(notExistProductRequest, memberAuthResponse.accessToken)
 
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
@@ -113,24 +75,13 @@ class CartProductControllerTest(
             }
 
             When("유효하지 않은 상품 수량을 담으면") {
-                val request = SaveCartProductRequest(
+                val invalidProductQuantityRequest = SaveCartProductRequest(
                     productId = savedProduct.id,
                     quantity = 1_000,
                     isMale = false,
                     deliveryMethod = "SAFETY"
                 )
-                val response = Given {
-                    log().all()
-                        .body(request)
-                        .header(AUTHORIZATION, memberAuthResponse.accessToken)
-                        .contentType("application/json")
-                } When {
-                    post("/carts")
-                } Then {
-                    log().all()
-                } Extract {
-                    response()
-                }
+                val response = requestSaveCartProduct(invalidProductQuantityRequest, memberAuthResponse.accessToken)
 
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)

--- a/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
@@ -1,0 +1,23 @@
+package com.petqua.test.fixture
+
+import com.petqua.domain.cart.CartProduct
+import com.petqua.domain.cart.CartProductQuantity
+import com.petqua.domain.cart.DeliveryMethod
+
+fun cartProduct(
+    id: Long = 1L,
+    memberId: Long = 1L,
+    productId: Long = 1L,
+    quantity: Int = 1,
+    isMale: Boolean = true,
+    deliveryMethod: DeliveryMethod = DeliveryMethod.COMMON,
+): CartProduct {
+    return CartProduct(
+        id = id,
+        memberId = memberId,
+        productId = productId,
+        quantity = CartProductQuantity(quantity),
+        isMale = isMale,
+        deliveryMethod = deliveryMethod,
+    )
+}


### PR DESCRIPTION
### 📌 관련 이슈
- closed #26 

### 📁 작업 설명
[작업 범위](https://github.com/petqua/backend/pull/34/files/b53c1f45fe971fa62ef2f7dab9d3bec413703347..ee0a8a63c24d40b07a3996b4480c1a8c8e38000d)
- 봉달 상품의 옵션을 수정하는 API 구현
권한 검증, 옵션 요청에 대한 유효값 검증 포함

- ControllerTest steps 방식 추가
ControllerTest에서 테스트 시 요구되는 사항들이 있었습니다.
봉달 상품 수정을 테스트 하기 위해선 `회원, 상품, 봉달 상품` 이 존재해야 했는데요. (이런 케이스는 많을 예정..)
봉달 상품 저장 역시 `Repository`를 통해 `save()`하려 했는데, 유효한 memberId가 필요했었습니다.
회원의 경우 id를 지정하여 `save()` 할 수 있지만, API요청에 사용 되는 accessToken과 지정한 member의 id가 다를 수 있더라구요!
ex)
```kotlin
val member = MemberRepository.save(member(id = 1L))
val memberAuthResponse = signInAsMember()

// memberAuthResponse.accessToken의 서명된 Id와 member.id가 다를 수 있음

header(HttpHeaders.AUTHORIZATION, accessToken) // accessToken 요청
patch("/carts/items/{cartProductId}/options", cartProductId) // 지정한 memberId로 생성한 cartProduct
```

그래서 실제 동작 과정 처럼 API를 통해 관리되도록 step을 추가했습니다.
step: [회원 가입]
step: [회원이 봉달 상품으로 등록]
검증: [해당 봉달 상품 수정 요청]

`CartProductControllerSteps.kt`에 해당되는 api step들을 모아두었습니다..!

### 기타
~- on #25~
- 저희 테스트의 Assertions를 모두 kotest 스타일로 바꾸는건 어떨까요? (문서: https://kotest.io/docs/assertions/core-matchers.html)
문서도 잘 정리되어 있고 기능도 많더라고요! 추후 `BigDecimal`에 대한 검증들도 많을 텐데 이것도 지원해주고 있습니다.
제가 제시한 만큼 제가 수정 담당할 생각이라 마음 편하게 의견주세요!