### PR TITLE
feature: 봉달 목록 조회 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -6,12 +6,10 @@ import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.common.domain.existByIdOrThrow
 import com.petqua.common.domain.findByIdOrThrow
-import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.cart.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
-import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
@@ -83,16 +81,6 @@ class CartProductService(
     @Transactional(readOnly = true)
     fun readAll(memberId: Long): List<CartProductResponse> {
         memberRepository.existByIdOrThrow(memberId, MemberException(NOT_FOUND_MEMBER))
-        val cartProducts = cartProductRepository.findAllByMemberId(memberId)
-        val products = productByIds(cartProducts)
-        return cartProducts.map {
-            products[it.id]?.let { product -> CartProductResponse.of(it, product) }
-                ?: CartProductResponse.fromDeletedProduct(it)
-        }
-    }
-
-    private fun productByIds(cartProducts: List<CartProduct>): Map<Long, ProductResponse> {
-        val productIdsFromCart = cartProducts.map { it.productId }
-        return productRepository.findAllProductResponseByIdIn(productIdsFromCart).associateBy { it.id }
+        return cartProductRepository.findAllCartResultsByMemberId(memberId)
     }
 }

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -85,6 +85,7 @@ class CartProductService(
         memberRepository.existByIdOrThrow(memberId, MemberException(NOT_FOUND_MEMBER))
         val cartProducts = cartProductRepository.findAllByMemberId(memberId)
         val products = productByIds(cartProducts)
+        val findAll = productRepository.findAll()
         return cartProducts.map {
             products[it.id]?.let { product -> CartProductResponse.of(it, product) }
                 ?: CartProductResponse.fromDeletedProduct(it)

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -1,14 +1,17 @@
 package com.petqua.application.cart
 
+import com.petqua.application.cart.dto.CartProductResponse
 import com.petqua.application.cart.dto.DeleteCartProductCommand
 import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.common.domain.existByIdOrThrow
 import com.petqua.common.domain.findByIdOrThrow
+import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.cart.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
@@ -75,5 +78,21 @@ class CartProductService(
         )
         cartProduct.validateOwner(command.memberId)
         cartProductRepository.delete(cartProduct)
+    }
+
+    @Transactional(readOnly = true)
+    fun readAll(memberId: Long): List<CartProductResponse> {
+        memberRepository.existByIdOrThrow(memberId, MemberException(NOT_FOUND_MEMBER))
+        val cartProducts = cartProductRepository.findAllByMemberId(memberId)
+        val products = productByIds(cartProducts)
+        return cartProducts.map {
+            products[it.id]?.let { product -> CartProductResponse.of(it, product) }
+                ?: CartProductResponse.fromDeletedProduct(it)
+        }
+    }
+
+    private fun productByIds(cartProducts: List<CartProduct>): Map<Long, ProductResponse> {
+        val productIdsFromCart = cartProducts.map { it.productId }
+        return productRepository.findAllProductResponseByIdIn(productIdsFromCart).associateBy { it.id }
     }
 }

--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -85,7 +85,6 @@ class CartProductService(
         memberRepository.existByIdOrThrow(memberId, MemberException(NOT_FOUND_MEMBER))
         val cartProducts = cartProductRepository.findAllByMemberId(memberId)
         val products = productByIds(cartProducts)
-        val findAll = productRepository.findAll()
         return cartProducts.map {
             products[it.id]?.let { product -> CartProductResponse.of(it, product) }
                 ?: CartProductResponse.fromDeletedProduct(it)

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -3,7 +3,7 @@ package com.petqua.application.cart.dto
 import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
-import com.petqua.domain.product.dto.ProductResponse
+import com.petqua.domain.product.Product
 
 data class SaveCartProductCommand(
     val memberId: Long,
@@ -52,40 +52,18 @@ data class CartProductResponse(
     val isOnSale: Boolean,
 ) {
 
-    companion object {
-        fun of(cartProduct: CartProduct, productResponse: ProductResponse): CartProductResponse {
-            return CartProductResponse(
-                id = cartProduct.id,
-                storeName = productResponse.storeName,
-                productId = productResponse.id,
-                productName = productResponse.name,
-                productThumbnailUrl = productResponse.thumbnailUrl,
-                productPrice = productResponse.price,
-                productDiscountRate = productResponse.discountRate,
-                productDiscountPrice = productResponse.discountPrice,
-                quantity = cartProduct.quantity.value,
-                isMale = cartProduct.isMale,
-                deliveryMethod = cartProduct.deliveryMethod.name,
-                isOnSale = true,
-            )
-        }
-
-
-        fun fromDeletedProduct(cartProduct: CartProduct): CartProductResponse {
-            return CartProductResponse(
-                id = cartProduct.id,
-                storeName = "",
-                productId = cartProduct.productId,
-                productName = "",
-                productThumbnailUrl = "",
-                productPrice = 0,
-                productDiscountRate = 0,
-                productDiscountPrice = 0,
-                quantity = cartProduct.quantity.value,
-                isMale = cartProduct.isMale,
-                deliveryMethod = cartProduct.deliveryMethod.name,
-                isOnSale = false,
-            )
-        }
-    }
+    constructor(cartProduct: CartProduct, product: Product?, storeName: String?) : this(
+        cartProduct.id,
+        storeName ?: "",
+        product?.id ?: cartProduct.productId,
+        product?.name ?: "",
+        product?.thumbnailUrl ?: "",
+        product?.price?.intValueExact() ?: 0,
+        product?.discountRate ?: 0,
+        product?.discountPrice?.intValueExact() ?: 0,
+        cartProduct.quantity.value,
+        cartProduct.isMale,
+        cartProduct.deliveryMethod.name,
+        product != null
+    )
 }

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -3,6 +3,7 @@ package com.petqua.application.cart.dto
 import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
+import com.petqua.domain.product.dto.ProductResponse
 
 data class SaveCartProductCommand(
     val memberId: Long,
@@ -35,3 +36,56 @@ data class DeleteCartProductCommand(
     val memberId: Long,
     val cartProductId: Long,
 )
+
+data class CartProductResponse(
+    val id: Long,
+    val storeName: String,
+    val productId: Long,
+    val productName: String,
+    val productThumbnailUrl: String,
+    val productPrice: Int,
+    val productDiscountRate: Int,
+    val productDiscountPrice: Int,
+    val quantity: Int,
+    val isMale: Boolean,
+    val deliveryMethod: String,
+    val isOnSale: Boolean,
+) {
+
+    companion object {
+        fun of(cartProduct: CartProduct, productResponse: ProductResponse): CartProductResponse {
+            return CartProductResponse(
+                id = cartProduct.id,
+                storeName = productResponse.storeName,
+                productId = productResponse.id,
+                productName = productResponse.name,
+                productThumbnailUrl = productResponse.thumbnailUrl,
+                productPrice = productResponse.price,
+                productDiscountRate = productResponse.discountRate,
+                productDiscountPrice = productResponse.discountPrice,
+                quantity = cartProduct.quantity.value,
+                isMale = cartProduct.isMale,
+                deliveryMethod = cartProduct.deliveryMethod.name,
+                isOnSale = true,
+            )
+        }
+
+
+        fun fromDeletedProduct(cartProduct: CartProduct): CartProductResponse {
+            return CartProductResponse(
+                id = cartProduct.id,
+                storeName = "",
+                productId = cartProduct.productId,
+                productName = "",
+                productThumbnailUrl = "",
+                productPrice = 0,
+                productDiscountRate = 0,
+                productDiscountPrice = 0,
+                quantity = cartProduct.quantity.value,
+                isMale = cartProduct.isMale,
+                deliveryMethod = cartProduct.deliveryMethod.name,
+                isOnSale = false,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -53,17 +53,17 @@ data class CartProductResponse(
 ) {
 
     constructor(cartProduct: CartProduct, product: Product?, storeName: String?) : this(
-        cartProduct.id,
-        storeName ?: "",
-        product?.id ?: cartProduct.productId,
-        product?.name ?: "",
-        product?.thumbnailUrl ?: "",
-        product?.price?.intValueExact() ?: 0,
-        product?.discountRate ?: 0,
-        product?.discountPrice?.intValueExact() ?: 0,
-        cartProduct.quantity.value,
-        cartProduct.isMale,
-        cartProduct.deliveryMethod.name,
-        product != null
+        id = cartProduct.id,
+        storeName = storeName ?: "",
+        productId = product?.id ?: 0L,
+        productName = product?.name ?: "",
+        productThumbnailUrl = product?.thumbnailUrl ?: "",
+        productPrice = product?.price?.intValueExact() ?: 0,
+        productDiscountRate = product?.discountRate ?: 0,
+        productDiscountPrice = product?.discountPrice?.intValueExact() ?: 0,
+        quantity = cartProduct.quantity.value,
+        isMale = cartProduct.isMale,
+        deliveryMethod = cartProduct.deliveryMethod.name,
+        isOnSale = product != null
     )
 }

--- a/src/main/kotlin/com/petqua/common/util/EntityManagerUtils.kt
+++ b/src/main/kotlin/com/petqua/common/util/EntityManagerUtils.kt
@@ -29,6 +29,17 @@ inline fun <reified T> EntityManager.createQuery(
         .resultList
 }
 
+inline fun <reified T> EntityManager.createQuery(
+    query: SelectQuery<*>,
+    context: JpqlRenderContext,
+    renderer: JpqlRenderer,
+): List<T> {
+    val rendered = renderer.render(query, context)
+    return this.createQuery(rendered.query, T::class.java)
+        .apply { rendered.params.forEach { (name, value) -> setParameter(name, value) } }
+        .resultList
+}
+
 inline fun <reified T> EntityManager.createCountQuery(
     query: SelectQuery<*>,
     context: JpqlRenderContext,

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepository.kt
@@ -1,0 +1,8 @@
+package com.petqua.domain.cart
+
+import com.petqua.application.cart.dto.CartProductResponse
+
+interface CartProductCustomRepository {
+
+    fun findAllCartResultsByMemberId(memberId: Long): List<CartProductResponse>
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.petqua.domain.cart
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.application.cart.dto.CartProductResponse
+import com.petqua.common.util.createQuery
+import com.petqua.domain.product.Product
+import com.petqua.domain.store.Store
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class CartProductCustomRepositoryImpl(
+    private val entityManager: EntityManager,
+    private val jpqlRenderContext: JpqlRenderContext,
+    private val jpqlRenderer: JpqlRenderer,
+) : CartProductCustomRepository {
+
+    override fun findAllCartResultsByMemberId(memberId: Long): List<CartProductResponse> {
+        val query = jpql {
+            selectNew<CartProductResponse>(
+                entity(CartProduct::class),
+                entity(Product::class),
+                path(Store::name)
+            ).from(
+                entity(CartProduct::class),
+                leftJoin(Product::class).on(path(CartProduct::productId).eq(path(Product::id))),
+                leftJoin(Store::class).on(path(Product::storeId).eq(path(Store::id))),
+            ).where(
+                path(CartProduct::memberId).eq(memberId)
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductCustomRepositoryImpl.kt
@@ -29,6 +29,8 @@ class CartProductCustomRepositoryImpl(
                 leftJoin(Store::class).on(path(Product::storeId).eq(path(Store::id))),
             ).where(
                 path(CartProduct::memberId).eq(memberId)
+            ).orderBy(
+                path(CartProduct::createdAt).desc()
             )
         }
 

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -2,7 +2,7 @@ package com.petqua.domain.cart
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CartProductRepository : JpaRepository<CartProduct, Long> {
+interface CartProductRepository : JpaRepository<CartProduct, Long>, CartProductCustomRepository {
 
     fun findByMemberIdAndProductIdAndIsMaleAndDeliveryMethod(
         memberId: Long,

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -11,5 +11,5 @@ interface CartProductRepository : JpaRepository<CartProduct, Long> {
         deliveryMethod: DeliveryMethod
     ): CartProduct?
 
-    fun findAllByIdIn(ids: List<Long>): List<CartProduct>
+    fun findAllByMemberId(id: Long): List<CartProduct>
 }

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
@@ -9,4 +9,6 @@ interface ProductCustomRepository {
     fun findAllByCondition(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse>
 
     fun countByCondition(condition: ProductReadCondition): Int
+
+    fun findAllProductResponseByIdIn(ids: List<Long>): List<ProductResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -106,7 +106,7 @@ class ProductCustomRepositoryImpl(
                 entity(Product::class),
                 join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
             ).where(
-                path(Product::id).`in`(ids)
+                predicateByIds(ids)
             )
         }
 
@@ -116,4 +116,6 @@ class ProductCustomRepositoryImpl(
             jpqlRenderer
         )
     }
+
+    private fun Jpql.predicateByIds(ids: List<Long>) = if (ids.isEmpty()) null else path(Product::id).`in`(ids)
 }

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -96,4 +96,24 @@ class ProductCustomRepositoryImpl(
             jpqlRenderer
         )
     }
+
+    override fun findAllProductResponseByIdIn(ids: List<Long>): List<ProductResponse> {
+        val query = jpql {
+            selectNew<ProductResponse>(
+                entity(Product::class),
+                path(Store::name)
+            ).from(
+                entity(Product::class),
+                join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
+            ).where(
+                path(Product::id).`in`(ids)
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer
+        )
+    }
 }

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -2,6 +2,7 @@ package com.petqua.presentation.cart
 
 import com.petqua.application.cart.CartProductService
 import com.petqua.application.cart.dto.DeleteCartProductCommand
+import com.petqua.application.cart.dto.CartProductResponse
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
@@ -9,6 +10,7 @@ import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -59,5 +61,13 @@ class CartProductController(
         )
         cartProductService.delete(command)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping
+    fun readAll(
+        @Auth loginMember: LoginMember,
+    ): ResponseEntity<List<CartProductResponse>> {
+        val responses = cartProductService.readAll(loginMember.memberId)
+        return ResponseEntity.ok(responses)
     }
 }

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -289,7 +289,7 @@ class CartProductServiceTest(
             productRepository.deleteById(productAId)
             val results = cartProductService.readAll(memberId)
 
-            Then("빈 리스트를 반환 한다") {
+            Then("상품의 판매 여부를 포함한 리스트를 반환 한다") {
                 assertSoftly(results) {
                     size shouldBe 3
                     find { it.productId == productAId }!!.isOnSale shouldBe false

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -173,16 +173,16 @@ class CartProductServiceTest(
                 cartProduct(
                     memberId = memberId,
                     productId = productId,
-                    isMale = true,
-                    deliveryMethod = COMMON
+                    isMale = false,
+                    deliveryMethod = SAFETY
                 )
             )
             val command = UpdateCartProductOptionCommand(
                 cartProductId = cartProduct.id,
                 memberId = memberId,
                 quantity = CartProductQuantity(3),
-                isMale = true,
-                deliveryMethod = COMMON,
+                isMale = false,
+                deliveryMethod = SAFETY,
             )
             Then("예외가 발생 한다") {
                 shouldThrow<CartProductException> {

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -292,7 +292,7 @@ class CartProductServiceTest(
             Then("상품의 판매 여부를 포함한 리스트를 반환 한다") {
                 assertSoftly(results) {
                     size shouldBe 3
-                    find { it.productId == productAId }!!.isOnSale shouldBe false
+                    find { it.productId == 0L }!!.isOnSale shouldBe false
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -10,6 +10,7 @@ import com.petqua.domain.cart.DeliveryMethod.COMMON
 import com.petqua.domain.cart.DeliveryMethod.SAFETY
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.store.StoreRepository
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.FORBIDDEN_CART_PRODUCT
@@ -22,6 +23,7 @@ import com.petqua.test.DataCleaner
 import com.petqua.test.fixture.cartProduct
 import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
+import com.petqua.test.fixture.store
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -35,6 +37,7 @@ class CartProductServiceTest(
     private val cartProductRepository: CartProductRepository,
     private val productRepository: ProductRepository,
     private val memberRepository: MemberRepository,
+    private val storeRepository: StoreRepository,
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
@@ -247,6 +250,58 @@ class CartProductServiceTest(
                 shouldThrow<CartProductException> {
                     cartProductService.delete(command)
                 }.exceptionType() shouldBe FORBIDDEN_CART_PRODUCT
+            }
+        }
+    }
+
+    Given("봉달 상품 조회시") {
+        val store = storeRepository.save(store(name = "store"))
+        val productAId = productRepository.save(product(storeId = store.id)).id
+        val productBId = productRepository.save(product(storeId = store.id)).id
+        val productCId = productRepository.save(product(storeId = store.id)).id
+        val memberId = memberRepository.save(member()).id
+        cartProductRepository.saveAll(
+            listOf(
+                cartProduct(memberId = memberId, productId = productAId),
+                cartProduct(memberId = memberId, productId = productBId),
+                cartProduct(memberId = memberId, productId = productCId),
+            )
+        )
+
+        When("봉달 상품이 있는 회원이 조회 하는 경우") {
+            val result = cartProductService.readAll(memberId)
+
+            Then("봉달 상품 리스트를 반환 한다") {
+                result.size shouldBe 3
+            }
+        }
+
+        When("봉달 상품이 없는 회원이 조회 하는 경우") {
+            val newMemberId = memberRepository.save(member()).id
+            val results = cartProductService.readAll(newMemberId)
+
+            Then("빈 리스트를 반환 한다") {
+                results.size shouldBe 0
+            }
+        }
+
+        When("봉달에 담아둔 상품이 삭제된 경우") {
+            productRepository.deleteById(productAId)
+            val results = cartProductService.readAll(memberId)
+
+            Then("빈 리스트를 반환 한다") {
+                assertSoftly(results) {
+                    size shouldBe 3
+                    find { it.productId == productAId }!!.isOnSale shouldBe false
+                }
+            }
+        }
+
+        When("존재 하지 않는 회원이 조회 하는 경우") {
+            Then("예외가 발생 한다") {
+                shouldThrow<MemberException> {
+                    cartProductService.readAll(Long.MIN_VALUE)
+                }.exceptionType() shouldBe NOT_FOUND_MEMBER
             }
         }
     }

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -177,6 +177,22 @@ class ProductCustomRepositoryImplTest(
         }
     }
 
+    Given("다중 id로 ProductResponse를 조회 할 때") {
+        val product1 = productRepository.save(product(name = "상품1", storeId = store.id))
+        val product2 = productRepository.save(product(name = "상품2", storeId = store.id))
+
+        When("id 목록을 입력하면") {
+            val products = productRepository.findAllProductResponseByIdIn(listOf(product1.id, product2.id))
+
+            Then("해당 id의 ProductResponse를 반환한다") {
+                products shouldContainExactly listOf(
+                    ProductResponse(product1, store.name),
+                    ProductResponse(product2, store.name),
+                )
+            }
+        }
+    }
+
     afterContainer {
         dataCleaner.clean()
     }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -77,3 +77,18 @@ fun requestDeleteCartProduct(
         response()
     }
 }
+
+fun requestReadAllCartProducts(
+    accessToken: String
+): Response {
+    return Given {
+        log().all()
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+    } When {
+        get("/carts")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -384,7 +384,7 @@ class CartProductControllerTest(
                     assertSoftly(response) {
                         statusCode shouldBe HttpStatus.OK.value()
                         responseBody.size shouldBe 3
-                        responseBody.find { it.productId == productA.id }!!.isOnSale shouldBe false
+                        responseBody.find { it.productId == 0L }!!.isOnSale shouldBe false
                     }
                 }
             }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -16,8 +16,9 @@ import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
 import com.petqua.test.fixture.store
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import org.assertj.core.api.Assertions.assertThat
+import io.kotest.matchers.string.shouldContain
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
@@ -46,8 +47,8 @@ class CartProductControllerTest(
 
                 Then("봉달 목록에 상품이 저장된다") {
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(CREATED.value())
-                        assertThat(response.header(HttpHeaders.LOCATION)).contains("/carts/items")
+                        statusCode shouldBe CREATED.value()
+                        header(HttpHeaders.LOCATION) shouldContain "/carts/items/1"
                     }
                 }
             }
@@ -68,8 +69,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(INVALID_DELIVERY_METHOD.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe INVALID_DELIVERY_METHOD.errorMessage()
                     }
                 }
             }
@@ -86,8 +87,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(NOT_FOUND.value())
-                        assertThat(errorResponse.message).isEqualTo(NOT_FOUND_PRODUCT.errorMessage())
+                        statusCode shouldBe NOT_FOUND.value()
+                        errorResponse.message shouldBe NOT_FOUND_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -104,8 +105,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage()
                     }
                 }
             }
@@ -124,8 +125,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(DUPLICATED_PRODUCT.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe DUPLICATED_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -150,7 +151,7 @@ class CartProductControllerTest(
                 )
 
                 Then("봉달 상품의 옵션이 수정된다") {
-                    assertThat(response.statusCode).isEqualTo(NO_CONTENT.value())
+                    response.statusCode shouldBe NO_CONTENT.value()
                 }
             }
         }
@@ -176,8 +177,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(NOT_FOUND.value())
-                        assertThat(errorResponse.message).isEqualTo(NOT_FOUND_CART_PRODUCT.errorMessage())
+                        statusCode shouldBe NOT_FOUND.value()
+                        errorResponse.message shouldBe NOT_FOUND_CART_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -198,8 +199,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe PRODUCT_QUANTITY_OVER_MAXIMUM.errorMessage()
                     }
                 }
             }
@@ -220,8 +221,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(INVALID_DELIVERY_METHOD.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe INVALID_DELIVERY_METHOD.errorMessage()
                     }
                 }
             }
@@ -243,8 +244,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(FORBIDDEN.value())
-                        assertThat(errorResponse.message).isEqualTo(FORBIDDEN_CART_PRODUCT.errorMessage())
+                        statusCode shouldBe FORBIDDEN.value()
+                        errorResponse.message shouldBe FORBIDDEN_CART_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -274,8 +275,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(BAD_REQUEST.value())
-                        assertThat(errorResponse.message).isEqualTo(DUPLICATED_PRODUCT.errorMessage())
+                        statusCode shouldBe BAD_REQUEST.value()
+                        errorResponse.message shouldBe DUPLICATED_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -294,7 +295,7 @@ class CartProductControllerTest(
                 )
 
                 Then("봉달 상품이 삭제된다") {
-                    assertThat(response.statusCode).isEqualTo(NO_CONTENT.value())
+                    response.statusCode shouldBe NO_CONTENT.value()
                 }
             }
         }
@@ -313,8 +314,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(NOT_FOUND.value())
-                        assertThat(errorResponse.message).isEqualTo(NOT_FOUND_CART_PRODUCT.errorMessage())
+                        statusCode shouldBe NOT_FOUND.value()
+                        errorResponse.message shouldBe NOT_FOUND_CART_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -329,8 +330,8 @@ class CartProductControllerTest(
                 Then("예외가 발생한다") {
                     val errorResponse = response.`as`(ExceptionResponse::class.java)
                     assertSoftly(response) {
-                        assertThat(statusCode).isEqualTo(FORBIDDEN.value())
-                        assertThat(errorResponse.message).isEqualTo(FORBIDDEN_CART_PRODUCT.errorMessage())
+                        statusCode shouldBe FORBIDDEN.value()
+                        errorResponse.message shouldBe FORBIDDEN_CART_PRODUCT.errorMessage()
                     }
                 }
             }
@@ -354,6 +355,7 @@ class CartProductControllerTest(
                     assertSoftly(response) {
                         statusCode shouldBe HttpStatus.OK.value()
                         responseBody.size shouldBe 3
+                        responseBody.map { it.productName }.toList() shouldContainAll listOf("쿠아1", "쿠아2", "쿠아3")
                     }
                 }
             }
@@ -376,13 +378,13 @@ class CartProductControllerTest(
                 productRepository.delete(productA)
                 val response = requestReadAllCartProducts(memberAuthResponse.accessToken)
 
-                Then("봉달 목록에서 삭제된 상품이 조회된다") {
+                Then("삭제된 상품은 구매 불가능 하도록 조회된다") {
                     val responseBody = response.`as`(Array<CartProductResponse>::class.java)
 
                     assertSoftly(response) {
                         statusCode shouldBe HttpStatus.OK.value()
                         responseBody.size shouldBe 3
-                        responseBody.toList().find { it.productId == productA.id }!!.isOnSale shouldBe false
+                        responseBody.find { it.productId == productA.id }!!.isOnSale shouldBe false
                     }
                 }
             }

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
@@ -10,12 +10,10 @@ import com.petqua.domain.product.Sorter.SALE_PRICE_DESC
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.StoreRepository
-import com.petqua.test.DataCleaner
+import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
 import com.petqua.test.fixture.productRecommendation
 import com.petqua.test.fixture.store
-import io.kotest.core.spec.style.BehaviorSpec
-import io.restassured.RestAssured
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -23,324 +21,316 @@ import io.restassured.module.kotlin.extensions.When
 import java.math.BigDecimal
 import kotlin.Long.Companion.MIN_VALUE
 import org.assertj.core.api.SoftAssertions.assertSoftly
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 class ProductControllerTest(
-    @LocalServerPort private val port: Int,
     private val productRepository: ProductRepository,
     private val storeRepository: StoreRepository,
     private val recommendationRepository: ProductRecommendationRepository,
-    private val dataCleaner: DataCleaner,
-) : BehaviorSpec({
+) : ApiTestConfig() {
 
-    RestAssured.port = port
-    val store = storeRepository.save(store())
+    init {
+        val store = storeRepository.save(store())
 
-    Given("개별 상품을 조회할 때") {
-        val productId = productRepository.save(product(storeId = store.id)).id
+        Given("개별 상품을 조회할 때") {
+            val productId = productRepository.save(product(storeId = store.id)).id
 
-        When("상품 ID를 입력하면") {
-            val response = Given {
-                log().all()
-                pathParam("productId", productId)
-            } When {
-                get("/products/{productId}")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("해당 ID의 상품이 반환된다") {
-                val productDetailResponse = response.`as`(ProductDetailResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productDetailResponse).isEqualTo(
-                        ProductDetailResponse(
-                            product = product(id = productId, storeId = store.id),
-                            storeName = store.name,
-                            reviewAverageScore = 0.0
-                        )
-                    )
-                }
-            }
-        }
-
-        When("존재하지 않는 상품 ID를 입력하면") {
-
-            Then("예외가 발생한다") {
-                Given {
+            When("상품 ID를 입력하면") {
+                val response = Given {
                     log().all()
-                    pathParam("productId", MIN_VALUE)
+                    pathParam("productId", productId)
                 } When {
                     get("/products/{productId}")
                 } Then {
                     log().all()
-                    statusCode(NOT_FOUND.value())
+                } Extract {
+                    response()
                 }
-            }
-        }
-    }
 
-    Given("조건에 따라 상품을 조회할 때") {
-        val product1 = productRepository.save(
-            product(
-                name = "상품1",
-                storeId = store.id,
-                discountPrice = BigDecimal.ZERO,
-                reviewCount = 0,
-                reviewTotalScore = 0
-            )
-        )
-        val product2 = productRepository.save(
-            product(
-                name = "상품2",
-                storeId = store.id,
-                discountPrice = BigDecimal.ONE,
-                reviewCount = 1,
-                reviewTotalScore = 1
-            )
-        )
-        val product3 = productRepository.save(
-            product(
-                name = "상품3",
-                storeId = store.id,
-                discountPrice = BigDecimal.ONE,
-                reviewCount = 1,
-                reviewTotalScore = 5
-            )
-        )
-        val product4 = productRepository.save(
-            product(
-                name = "상품4",
-                storeId = store.id,
-                discountPrice = BigDecimal.TEN,
-                reviewCount = 2,
-                reviewTotalScore = 10
-            )
-        )
+                Then("해당 ID의 상품이 반환된다") {
+                    val productDetailResponse = response.`as`(ProductDetailResponse::class.java)
 
-        recommendationRepository.save(productRecommendation(productId = product1.id))
-        recommendationRepository.save(productRecommendation(productId = product2.id))
-
-        When("마지막으로 조회한 Id를 입력하면") {
-            val response = Given {
-                log().all()
-                param("lastViewedId", product4.id)
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("해당 ID의 다음 상품들이 최신 등록 순으로 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(
-                                ProductResponse(product3, store.name),
-                                ProductResponse(product2, store.name),
-                                ProductResponse(product1, store.name)
-                            ),
-                            hasNextPage = false,
-                            totalProductsCount = 4
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productDetailResponse).isEqualTo(
+                            ProductDetailResponse(
+                                product = product(id = productId, storeId = store.id),
+                                storeName = store.name,
+                                reviewAverageScore = 0.0
+                            )
                         )
-                    )
+                    }
+                }
+            }
+
+            When("존재하지 않는 상품 ID를 입력하면") {
+
+                Then("예외가 발생한다") {
+                    Given {
+                        log().all()
+                        pathParam("productId", MIN_VALUE)
+                    } When {
+                        get("/products/{productId}")
+                    } Then {
+                        log().all()
+                        statusCode(NOT_FOUND.value())
+                    }
                 }
             }
         }
 
-        When("개수 제한을 입력하면") {
-            val response = Given {
-                log().all()
-                param("limit", 1)
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("해당 개수와 함께 다음 페이지가 존재하는지 여부가 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(ProductResponse(product4, store.name)),
-                            hasNextPage = true,
-                            totalProductsCount = 4
-                        )
-                    )
-                }
-            }
-        }
-
-        When("추천 조건으로 조회하면") {
-            val response = Given {
-                log().all()
-                param("sourceType", HOME_RECOMMENDED.name)
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("추천 상품들이, 최신 등록 순으로 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(
-                                ProductResponse(product2, store.name),
-                                ProductResponse(product1, store.name)
-                            ),
-                            hasNextPage = false,
-                            totalProductsCount = 2
-                        )
-                    )
-                }
-            }
-        }
-
-        When("추천 조건으로, 가격 낮은 순으로 조회하면") {
-            val response = Given {
-                log().all()
-                params(
-                    "sourceType", HOME_RECOMMENDED.name,
-                    "sorter", SALE_PRICE_ASC.name
+        Given("조건에 따라 상품을 조회할 때") {
+            val product1 = productRepository.save(
+                product(
+                    name = "상품1",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.ZERO,
+                    reviewCount = 0,
+                    reviewTotalScore = 0
                 )
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("추천 상품들이, 가격 낮은 순으로 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(
-                                ProductResponse(product1, store.name),
-                                ProductResponse(product2, store.name)
-                            ),
-                            hasNextPage = false,
-                            totalProductsCount = 2
-                        )
-                    )
-                }
-            }
-        }
-
-        When("신규 입고 조건으로 조회하면") {
-            val response = Given {
-                log().all()
-                param("sourceType", HOME_NEW_ENROLLMENT.name)
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
-
-            Then("신규 입고 상품들이 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
-
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(
-                                ProductResponse(product4, store.name),
-                                ProductResponse(product3, store.name),
-                                ProductResponse(product2, store.name),
-                                ProductResponse(product1, store.name)
-                            ),
-                            hasNextPage = false,
-                            totalProductsCount = 4
-                        )
-                    )
-                }
-            }
-        }
-
-        When("신규 입고 조건으로, 가격 높은 순으로 조회하면") {
-            val response = Given {
-                log().all()
-                params(
-                    "sourceType", HOME_NEW_ENROLLMENT.name,
-                    "sorter", SALE_PRICE_DESC.name
+            )
+            val product2 = productRepository.save(
+                product(
+                    name = "상품2",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.ONE,
+                    reviewCount = 1,
+                    reviewTotalScore = 1
                 )
-            } When {
-                get("/products")
-            } Then {
-                log().all()
-            } Extract {
-                response()
-            }
+            )
+            val product3 = productRepository.save(
+                product(
+                    name = "상품3",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.ONE,
+                    reviewCount = 1,
+                    reviewTotalScore = 5
+                )
+            )
+            val product4 = productRepository.save(
+                product(
+                    name = "상품4",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.TEN,
+                    reviewCount = 2,
+                    reviewTotalScore = 10
+                )
+            )
 
-            Then("상품들이 최신 등록 순으로 반환된다") {
-                val productsResponse = response.`as`(ProductsResponse::class.java)
+            recommendationRepository.save(productRecommendation(productId = product1.id))
+            recommendationRepository.save(productRecommendation(productId = product2.id))
 
-                assertSoftly {
-                    it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
-                    it.assertThat(productsResponse).isEqualTo(
-                        ProductsResponse(
-                            products = listOf(
-                                ProductResponse(product4, store.name),
-                                ProductResponse(product3, store.name),
-                                ProductResponse(product2, store.name),
-                                ProductResponse(product1, store.name)
-                            ),
-                            hasNextPage = false,
-                            totalProductsCount = 4
-                        )
-                    )
-                }
-            }
-        }
-
-        When("조건을 잘못 기입해서 조회하면") {
-
-            Then("예외가 발생한다") {
-                Given {
+            When("마지막으로 조회한 Id를 입력하면") {
+                val response = Given {
                     log().all()
-                    param("sourceType", "wrongType")
+                    param("lastViewedId", product4.id)
                 } When {
                     get("/products")
                 } Then {
                     log().all()
-                    statusCode(BAD_REQUEST.value())
+                } Extract {
+                    response()
+                }
+
+                Then("해당 ID의 다음 상품들이 최신 등록 순으로 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(
+                                    ProductResponse(product3, store.name),
+                                    ProductResponse(product2, store.name),
+                                    ProductResponse(product1, store.name)
+                                ),
+                                hasNextPage = false,
+                                totalProductsCount = 4
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("개수 제한을 입력하면") {
+                val response = Given {
+                    log().all()
+                    param("limit", 1)
+                } When {
+                    get("/products")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("해당 개수와 함께 다음 페이지가 존재하는지 여부가 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(ProductResponse(product4, store.name)),
+                                hasNextPage = true,
+                                totalProductsCount = 4
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("추천 조건으로 조회하면") {
+                val response = Given {
+                    log().all()
+                    param("sourceType", HOME_RECOMMENDED.name)
+                } When {
+                    get("/products")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("추천 상품들이, 최신 등록 순으로 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(
+                                    ProductResponse(product2, store.name),
+                                    ProductResponse(product1, store.name)
+                                ),
+                                hasNextPage = false,
+                                totalProductsCount = 2
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("추천 조건으로, 가격 낮은 순으로 조회하면") {
+                val response = Given {
+                    log().all()
+                    params(
+                        "sourceType", HOME_RECOMMENDED.name,
+                        "sorter", SALE_PRICE_ASC.name
+                    )
+                } When {
+                    get("/products")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("추천 상품들이, 가격 낮은 순으로 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(
+                                    ProductResponse(product1, store.name),
+                                    ProductResponse(product2, store.name)
+                                ),
+                                hasNextPage = false,
+                                totalProductsCount = 2
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("신규 입고 조건으로 조회하면") {
+                val response = Given {
+                    log().all()
+                    param("sourceType", HOME_NEW_ENROLLMENT.name)
+                } When {
+                    get("/products")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("신규 입고 상품들이 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(
+                                    ProductResponse(product4, store.name),
+                                    ProductResponse(product3, store.name),
+                                    ProductResponse(product2, store.name),
+                                    ProductResponse(product1, store.name)
+                                ),
+                                hasNextPage = false,
+                                totalProductsCount = 4
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("신규 입고 조건으로, 가격 높은 순으로 조회하면") {
+                val response = Given {
+                    log().all()
+                    params(
+                        "sourceType", HOME_NEW_ENROLLMENT.name,
+                        "sorter", SALE_PRICE_DESC.name
+                    )
+                } When {
+                    get("/products")
+                } Then {
+                    log().all()
+                } Extract {
+                    response()
+                }
+
+                Then("상품들이 최신 등록 순으로 반환된다") {
+                    val productsResponse = response.`as`(ProductsResponse::class.java)
+
+                    assertSoftly {
+                        it.assertThat(response.statusCode).isEqualTo(HttpStatus.OK.value())
+                        it.assertThat(productsResponse).isEqualTo(
+                            ProductsResponse(
+                                products = listOf(
+                                    ProductResponse(product4, store.name),
+                                    ProductResponse(product3, store.name),
+                                    ProductResponse(product2, store.name),
+                                    ProductResponse(product1, store.name)
+                                ),
+                                hasNextPage = false,
+                                totalProductsCount = 4
+                            )
+                        )
+                    }
+                }
+            }
+
+            When("조건을 잘못 기입해서 조회하면") {
+
+                Then("예외가 발생한다") {
+                    Given {
+                        log().all()
+                        param("sourceType", "wrongType")
+                    } When {
+                        get("/products")
+                    } Then {
+                        log().all()
+                        statusCode(BAD_REQUEST.value())
+                    }
                 }
             }
         }
     }
+}
 
-    afterContainer {
-        dataCleaner.clean()
-    }
-})

--- a/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
@@ -5,7 +5,7 @@ import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
 
 fun cartProduct(
-    id: Long = 1L,
+    id: Long = 0L,
     memberId: Long = 1L,
     productId: Long = 1L,
     quantity: Int = 1,

--- a/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
@@ -4,7 +4,7 @@ import com.petqua.domain.auth.Authority
 import com.petqua.domain.member.Member
 
 fun member(
-    id: Long = 1L,
+    id: Long = 0L,
     oauthId: String = "oauthId",
     oauthServerNumber: Int = 1,
     authority: Authority = Authority.MEMBER


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #28 

### 📁 작업 설명
- 봉달에 담겨 있는 상품 조회 API 구현
간접 참조로 되어 있는 product를 조회하기 위해 `findAllProductResponseByIdIn()`을 추가 했습니다.

- 테스트 fixture 개선
fixture에서 `id = 1L`로 지정하다 보니 생성하고 저장할 때 동일한 객체로 판단해서 update 쿼리가 날아가는 이슈를 겪었습니다.. 수정했어요! 948eaf8ce18893ff6f06fe93a46b082b1449b6f3

### 기타
~- on #37~
