### PR TITLE
feature: Authorization 헤더 파싱 로직 추가

### DIFF
--- a/src/main/kotlin/com/petqua/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthService.kt
@@ -1,10 +1,6 @@
 package com.petqua.application.auth
 
 import com.petqua.common.domain.findByIdOrThrow
-import com.petqua.exception.auth.AuthException
-import com.petqua.exception.auth.AuthExceptionType.EXPIRED_REFRESH_TOKEN
-import com.petqua.exception.auth.AuthExceptionType.INVALID_REFRESH_TOKEN
-import com.petqua.exception.auth.AuthExceptionType.NOT_RENEWABLE_ACCESS_TOKEN
 import com.petqua.domain.auth.Authority.MEMBER
 import com.petqua.domain.auth.oauth.OauthClientProvider
 import com.petqua.domain.auth.oauth.OauthServerType
@@ -15,10 +11,16 @@ import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import com.petqua.domain.member.Member
 import com.petqua.domain.member.MemberRepository
+import com.petqua.exception.auth.AuthException
+import com.petqua.exception.auth.AuthExceptionType.EXPIRED_REFRESH_TOKEN
+import com.petqua.exception.auth.AuthExceptionType.INVALID_REFRESH_TOKEN
+import com.petqua.exception.auth.AuthExceptionType.NOT_RENEWABLE_ACCESS_TOKEN
+import com.petqua.exception.member.MemberException
+import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
+import java.net.URI
+import java.util.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.net.URI
-import java.util.Date
 
 @Transactional
 @Service
@@ -53,7 +55,7 @@ class AuthService(
         if (savedRefreshToken.token != refreshToken) {
             throw AuthException(INVALID_REFRESH_TOKEN)
         }
-        val member = memberRepository.findByIdOrThrow(savedRefreshToken.memberId)
+        val member = memberRepository.findByIdOrThrow(savedRefreshToken.memberId, MemberException(NOT_FOUND_MEMBER))
         val authToken = createAuthToken(member)
         return AuthTokenInfo(
             accessToken = authToken.accessToken,

--- a/src/main/kotlin/com/petqua/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthService.kt
@@ -17,10 +17,10 @@ import com.petqua.exception.auth.AuthExceptionType.INVALID_REFRESH_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.NOT_RENEWABLE_ACCESS_TOKEN
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
-import java.net.URI
-import java.util.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.net.URI
+import java.util.Date
 
 @Transactional
 @Service

--- a/src/main/kotlin/com/petqua/common/config/WebConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/WebConfig.kt
@@ -2,6 +2,7 @@ package com.petqua.common.config
 
 import com.petqua.presentation.auth.LoginArgumentResolver
 import com.petqua.presentation.auth.OauthServerTypeConverter
+import com.petqua.presentation.auth.TokenArgumentResolver
 import org.springframework.context.annotation.Configuration
 
 import org.springframework.format.FormatterRegistry
@@ -11,7 +12,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebConfig(
-    private val loginArgumentResolver: LoginArgumentResolver
+    private val loginArgumentResolver: LoginArgumentResolver,
+    private val tokenArgumentResolver: TokenArgumentResolver,
 ) : WebMvcConfigurer {
 
     override fun addFormatters(registry: FormatterRegistry) {
@@ -19,6 +21,11 @@ class WebConfig(
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
-        resolvers.add(loginArgumentResolver)
+        resolvers.addAll(
+            listOf(
+                loginArgumentResolver,
+                tokenArgumentResolver,
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/petqua/common/util/WebUtils.kt
+++ b/src/main/kotlin/com/petqua/common/util/WebUtils.kt
@@ -1,0 +1,25 @@
+package com.petqua.common.util
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.context.request.NativeWebRequest
+
+fun NativeWebRequest.getHttpServletRequestOrThrow(
+    exceptionSupplier: () -> Exception = { IllegalStateException("HTTP 요청에 접근할 수 없습니다") }
+): HttpServletRequest {
+    return this.getNativeRequest(HttpServletRequest::class.java) ?: throw exceptionSupplier()
+}
+
+fun HttpServletRequest.getCookieValueOrThrow(
+    name: String,
+    exceptionSupplier: () -> Exception = { IllegalArgumentException("$name 쿠키를 찾을 수 없습니다") }
+): String {
+    val cookies = this.cookies ?: throw exceptionSupplier()
+    return cookies.first() { it.name == name }.value ?: throw exceptionSupplier()
+}
+
+fun HttpServletRequest.getHeaderOrThrow(
+    name: String,
+    exceptionSupplier: () -> Exception = { IllegalArgumentException("$name 헤더를 찾을 수 없습니다") }
+): String {
+    return this.getHeader(name) ?: throw exceptionSupplier()
+}

--- a/src/main/kotlin/com/petqua/domain/auth/token/AuthTokenProvider.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/AuthTokenProvider.kt
@@ -5,10 +5,10 @@ import com.petqua.exception.auth.AuthException
 import com.petqua.exception.auth.AuthExceptionType.INVALID_ACCESS_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.INVALID_REFRESH_TOKEN
 import io.jsonwebtoken.JwtException
-import java.util.*
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
+import java.util.Date
 
 private const val EMPTY_SUBJECT = ""
 

--- a/src/main/kotlin/com/petqua/domain/auth/token/AuthTokenProvider.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/AuthTokenProvider.kt
@@ -1,16 +1,14 @@
 package com.petqua.domain.auth.token
 
+import com.petqua.domain.member.Member
 import com.petqua.exception.auth.AuthException
-import com.petqua.exception.auth.AuthExceptionType.EXPIRED_ACCESS_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.INVALID_ACCESS_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.INVALID_REFRESH_TOKEN
-import com.petqua.domain.member.Member
-import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.JwtException
+import java.util.*
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
-import java.util.Date
 
 private const val EMPTY_SUBJECT = ""
 
@@ -33,22 +31,6 @@ class AuthTokenProvider(
             accessToken = jwtProvider.createToken(accessToken.getClaims(), properties.accessTokenLiveTime, issuedDate),
             refreshToken = jwtProvider.createToken(EMPTY_SUBJECT, properties.refreshTokenLiveTime, issuedDate)
         )
-    }
-
-    fun isValidToken(token: String): Boolean {
-        return jwtProvider.isValidToken(token)
-    }
-
-    fun getAccessTokenClaimsOrThrow(token: String): AccessTokenClaims {
-        try {
-            return AccessTokenClaims.from(jwtProvider.getPayload(token))
-        } catch (e: ExpiredJwtException) {
-            throw AuthException(EXPIRED_ACCESS_TOKEN)
-        } catch (e: JwtException) {
-            throw AuthException(INVALID_ACCESS_TOKEN)
-        } catch (e: NullPointerException) {
-            throw AuthException(INVALID_ACCESS_TOKEN)
-        }
     }
 
     fun isExpiredAccessToken(token: String): Boolean {

--- a/src/main/kotlin/com/petqua/domain/auth/token/JwtProvider.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/JwtProvider.kt
@@ -8,10 +8,10 @@ import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
-import java.nio.charset.StandardCharsets
-import java.util.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.Date
 import javax.crypto.SecretKey
 
 

--- a/src/main/kotlin/com/petqua/domain/auth/token/JwtProvider.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/JwtProvider.kt
@@ -8,10 +8,10 @@ import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
+import java.nio.charset.StandardCharsets
+import java.util.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.nio.charset.StandardCharsets
-import java.util.Date
 import javax.crypto.SecretKey
 
 
@@ -47,15 +47,6 @@ class JwtProvider(
             .compact()
     }
 
-    fun isValidToken(token: String): Boolean {
-        try {
-            parseToken(token)
-        } catch (e: Exception) {
-            return false
-        }
-        return true
-    }
-
     fun isExpiredToken(token: String): Boolean {
         try {
             parseToken(token)
@@ -67,7 +58,7 @@ class JwtProvider(
 
     fun getPayload(token: String): Map<String, String> {
         val tokenClaims = parseToken(token)
-        return tokenClaims.body.entries.associate {(key, value) ->
+        return tokenClaims.body.entries.associate { (key, value) ->
             key to value.toString()
         }
     }

--- a/src/main/kotlin/com/petqua/exception/auth/AuthExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/auth/AuthExceptionType.kt
@@ -15,6 +15,8 @@ enum class AuthExceptionType(
     NOT_RENEWABLE_ACCESS_TOKEN(BAD_REQUEST, "유효한 AccessToken은 갱신할 수 없습니다."),
     INVALID_ACCESS_TOKEN(BAD_REQUEST, "올바른 형태의 AccessToken이 아닙니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "올바른 형태의 RefreshToken이 아닙니다."),
+    INVALID_AUTH_HEADER(BAD_REQUEST, "올바른 형태의 Authorization 헤더가 아닙니다."),
+    INVALID_AUTH_COOKIE(BAD_REQUEST, "올바른 형태의 쿠키가 아닙니다."),
 
     UNSUPPORTED_AUTHORITY(BAD_REQUEST, "해당하는 권한이 존재하지 않습니다."),
     ;

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -2,16 +2,15 @@ package com.petqua.presentation.auth
 
 import com.petqua.application.auth.AuthService
 import com.petqua.application.auth.AuthTokenInfo
+import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.oauth.OauthServerType
-import org.springframework.http.HttpHeaders.AUTHORIZATION
+import com.petqua.domain.auth.token.AuthToken
 import org.springframework.http.HttpHeaders.SET_COOKIE
 import org.springframework.http.HttpStatus.FOUND
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -50,10 +49,9 @@ class AuthController(
 
     @GetMapping("/token")
     fun extendLogin(
-        @RequestHeader(AUTHORIZATION) accessToken: String,
-        @CookieValue("refresh-token") refreshToken: String,
+        @Auth authToken: AuthToken,
     ): ResponseEntity<AuthResponse> {
-        val authTokenInfo = authService.extendLogin(accessToken, refreshToken)
+        val authTokenInfo = authService.extendLogin(authToken.accessToken, authToken.refreshToken)
         val refreshTokenCookie = createRefreshTokenCookie(authTokenInfo)
         val authResponse = AuthResponse(
             accessToken = authTokenInfo.accessToken

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
@@ -1,0 +1,58 @@
+package com.petqua.presentation.auth
+
+import com.petqua.common.util.getCookieValueOrThrow
+import com.petqua.common.util.getHeaderOrThrow
+import com.petqua.common.util.throwExceptionWhen
+import com.petqua.domain.auth.token.AccessTokenClaims
+import com.petqua.domain.auth.token.JwtProvider
+import com.petqua.exception.auth.AuthException
+import com.petqua.exception.auth.AuthExceptionType.EXPIRED_ACCESS_TOKEN
+import com.petqua.exception.auth.AuthExceptionType.INVALID_ACCESS_TOKEN
+import com.petqua.exception.auth.AuthExceptionType.INVALID_AUTH_COOKIE
+import com.petqua.exception.auth.AuthExceptionType.INVALID_AUTH_HEADER
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.stereotype.Component
+
+private const val AUTHORIZATION_PREFIX = "Bearer "
+private const val EMPTY = ""
+private const val REFRESH_TOKEN = "refresh-token"
+
+@Component
+class AuthExtractor(
+    private val jwtProvider: JwtProvider,
+) {
+
+    fun extractHeaderToken(request: HttpServletRequest): String {
+        val header = request.getHeaderOrThrow(AUTHORIZATION) { AuthException(INVALID_AUTH_HEADER) }
+        return parse(header)
+    }
+
+    private fun parse(header: String): String {
+        validateHeader(header)
+        return header.replace(AUTHORIZATION_PREFIX, EMPTY)
+    }
+
+    private fun validateHeader(header: String) {
+        throwExceptionWhen(header.isBlank() || !header.startsWith(AUTHORIZATION_PREFIX))
+        { AuthException(INVALID_AUTH_HEADER) }
+    }
+
+    fun extractCookieToken(request: HttpServletRequest): String {
+        return request.getCookieValueOrThrow(REFRESH_TOKEN) { AuthException(INVALID_AUTH_COOKIE) }
+    }
+
+    fun getAccessTokenClaimsOrThrow(token: String): AccessTokenClaims {
+        try {
+            return AccessTokenClaims.from(jwtProvider.getPayload(token))
+        } catch (e: ExpiredJwtException) {
+            throw AuthException(EXPIRED_ACCESS_TOKEN)
+        } catch (e: JwtException) {
+            throw AuthException(INVALID_ACCESS_TOKEN)
+        } catch (e: NullPointerException) {
+            throw AuthException(INVALID_ACCESS_TOKEN)
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
@@ -25,7 +25,7 @@ class AuthExtractor(
     private val jwtProvider: JwtProvider,
 ) {
 
-    fun extractHeaderToken(request: HttpServletRequest): String {
+    fun extractAccessToken(request: HttpServletRequest): String {
         val header = request.getHeaderOrThrow(AUTHORIZATION) { AuthException(INVALID_AUTH_HEADER) }
         return parse(header)
     }
@@ -40,7 +40,7 @@ class AuthExtractor(
         { AuthException(INVALID_AUTH_HEADER) }
     }
 
-    fun extractCookieToken(request: HttpServletRequest): String {
+    fun extractRefreshToken(request: HttpServletRequest): String {
         return request.getCookieValueOrThrow(REFRESH_TOKEN) { AuthException(INVALID_AUTH_COOKIE) }
     }
 

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
@@ -17,7 +17,6 @@ import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.stereotype.Component
 
 private const val AUTHORIZATION_PREFIX = "Bearer "
-private const val EMPTY = ""
 private const val REFRESH_TOKEN = "refresh-token"
 
 @Component
@@ -32,7 +31,7 @@ class AuthExtractor(
 
     private fun parse(header: String): String {
         validateHeader(header)
-        return header.replace(AUTHORIZATION_PREFIX, EMPTY)
+        return header.removePrefix(AUTHORIZATION_PREFIX)
     }
 
     private fun validateHeader(header: String) {

--- a/src/main/kotlin/com/petqua/presentation/auth/LoginArgumentResolver.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/LoginArgumentResolver.kt
@@ -27,7 +27,7 @@ class LoginArgumentResolver(
         binderFactory: WebDataBinderFactory?
     ): LoginMember {
         val request = webRequest.getHttpServletRequestOrThrow()
-        val token = authExtractor.extractHeaderToken(request)
+        val token = authExtractor.extractAccessToken(request)
         val accessTokenClaims = authExtractor.getAccessTokenClaimsOrThrow(token)
         return LoginMember.from(accessTokenClaims)
     }

--- a/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
@@ -27,8 +27,8 @@ class TokenArgumentResolver(
         binderFactory: WebDataBinderFactory?
     ): AuthToken {
         val request = webRequest.getHttpServletRequestOrThrow()
-        val accessToken = authExtractor.extractHeaderToken(request)
-        val refreshToken = authExtractor.extractCookieToken(request)
+        val accessToken = authExtractor.extractAccessToken(request)
+        val refreshToken = authExtractor.extractRefreshToken(request)
         return AuthToken(accessToken, refreshToken)
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
@@ -2,7 +2,7 @@ package com.petqua.presentation.auth
 
 import com.petqua.common.util.getHttpServletRequestOrThrow
 import com.petqua.domain.auth.Auth
-import com.petqua.domain.auth.LoginMember
+import com.petqua.domain.auth.token.AuthToken
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory
@@ -11,13 +11,13 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 
 @Component
-class LoginArgumentResolver(
+class TokenArgumentResolver(
     private val authExtractor: AuthExtractor,
 ) : HandlerMethodArgumentResolver {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(Auth::class.java)
-                && parameter.parameterType == LoginMember::class.java
+                && parameter.parameterType == AuthToken::class.java
     }
 
     override fun resolveArgument(
@@ -25,10 +25,10 @@ class LoginArgumentResolver(
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): LoginMember {
+    ): AuthToken {
         val request = webRequest.getHttpServletRequestOrThrow()
-        val token = authExtractor.extractHeaderToken(request)
-        val accessTokenClaims = authExtractor.getAccessTokenClaimsOrThrow(token)
-        return LoginMember.from(accessTokenClaims)
+        val accessToken = authExtractor.extractHeaderToken(request)
+        val refreshToken = authExtractor.extractCookieToken(request)
+        return AuthToken(accessToken, refreshToken)
     }
 }

--- a/src/test/kotlin/com/petqua/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/auth/AuthServiceTest.kt
@@ -1,25 +1,27 @@
 package com.petqua.application.auth
 
-import com.petqua.exception.auth.AuthException
-import com.petqua.exception.auth.AuthExceptionType
 import com.petqua.domain.auth.oauth.OauthServerType.KAKAO
 import com.petqua.domain.auth.token.AuthTokenProvider
+import com.petqua.domain.auth.token.JwtProvider
 import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import com.petqua.domain.member.MemberRepository
+import com.petqua.exception.auth.AuthException
+import com.petqua.exception.auth.AuthExceptionType
+import com.petqua.exception.member.MemberException
 import com.petqua.test.DataCleaner
 import com.petqua.test.config.OauthTestConfig
 import com.petqua.test.fixture.member
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import java.lang.System.currentTimeMillis
+import java.util.*
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import org.springframework.context.annotation.Import
-import java.lang.System.currentTimeMillis
-import java.util.Date
-
 
 @SpringBootTest(webEnvironment = NONE)
 @Import(OauthTestConfig::class)
@@ -27,6 +29,7 @@ class AuthServiceTest(
     private var authService: AuthService,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val authTokenProvider: AuthTokenProvider,
+    private val jwtProvider: JwtProvider,
     private val memberRepository: MemberRepository,
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
@@ -38,8 +41,12 @@ class AuthServiceTest(
 
             Then("멤버의 인증 토큰을 발급한다") {
                 assertSoftly(authTokenInfo) {
-                    authTokenProvider.isValidToken(accessToken) shouldBe true
-                    authTokenProvider.isValidToken(refreshToken) shouldBe true
+                    shouldNotThrow<MemberException> {
+                        jwtProvider.parseToken(accessToken)
+                    }
+                    shouldNotThrow<MemberException> {
+                        jwtProvider.parseToken(refreshToken)
+                    }
                 }
             }
 
@@ -64,8 +71,14 @@ class AuthServiceTest(
             val authTokenInfo = authService.extendLogin(expiredAccessToken, refreshToken)
 
             Then("멤버의 인증 토큰을 발급한다") {
-                authTokenProvider.isValidToken(authTokenInfo.accessToken) shouldBe true
-                authTokenProvider.isValidToken(authTokenInfo.refreshToken) shouldBe true
+                assertSoftly(authTokenInfo) {
+                    shouldNotThrow<MemberException> {
+                        jwtProvider.parseToken(accessToken)
+                    }
+                    shouldNotThrow<MemberException> {
+                        jwtProvider.parseToken(refreshToken)
+                    }
+                }
             }
 
             Then("발급한 refreshToken을 저장한다") {

--- a/src/test/kotlin/com/petqua/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/auth/AuthServiceTest.kt
@@ -17,11 +17,11 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import java.lang.System.currentTimeMillis
-import java.util.*
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import org.springframework.context.annotation.Import
+import java.lang.System.currentTimeMillis
+import java.util.Date
 
 @SpringBootTest(webEnvironment = NONE)
 @Import(OauthTestConfig::class)

--- a/src/test/kotlin/com/petqua/domain/auth/AuthTokenProviderTest.kt
+++ b/src/test/kotlin/com/petqua/domain/auth/AuthTokenProviderTest.kt
@@ -13,13 +13,13 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import java.util.*
-import org.springframework.boot.test.context.SpringBootTest
+import java.util.Date
 
 @SpringBootTest
 class AuthTokenProviderTest(

--- a/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
@@ -21,6 +21,7 @@ import java.util.Date
 class AuthControllerTest(
     private val memberRepository: MemberRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val authTokenProvider: AuthTokenProvider,
 ) : ApiTestConfig() {
 
     init {

--- a/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
@@ -1,5 +1,6 @@
 package com.petqua.presentation.auth
 
+import com.petqua.domain.auth.token.AuthTokenProvider
 import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import com.petqua.domain.member.MemberRepository
@@ -13,14 +14,13 @@ import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.springframework.context.annotation.Import
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.OK
 import java.util.Date
 
 @Import(OauthTestConfig::class)
 class AuthControllerTest(
-        private val memberRepository: MemberRepository,
-        private val refreshTokenRepository: RefreshTokenRepository,
+    private val memberRepository: MemberRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
 ) : ApiTestConfig() {
 
     init {
@@ -51,11 +51,18 @@ class AuthControllerTest(
             val member = memberRepository.save(member())
             val expiredAccessToken = authTokenProvider.createAuthToken(member, Date(0)).accessToken
             val refreshToken = authTokenProvider.createAuthToken(member, Date()).refreshToken
-            refreshTokenRepository.save(RefreshToken(memberId = member.id, token = refreshToken))
+            refreshTokenRepository.save(
+                RefreshToken(
+                    memberId = member.id,
+                    token = refreshToken
+                )
+            )
 
             When("요청하면") {
                 val response = Given {
-                    log().all().header(HttpHeaders.AUTHORIZATION, expiredAccessToken).cookie("refresh-token", refreshToken)
+                    log().all()
+                    auth().preemptive().oauth2(expiredAccessToken)
+                    cookie("refresh-token", refreshToken)
                 } When {
                     get("/auth/token")
                 } Then {

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -16,7 +16,7 @@ fun requestSaveCartProduct(
     return Given {
         log().all()
             .body(request)
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .auth().preemptive().oauth2(accessToken)
             .contentType("application/json")
     } When {
         post("/carts")
@@ -50,7 +50,7 @@ fun requestUpdateCartProductOption(
     return Given {
         log().all()
             .body(request)
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .auth().preemptive().oauth2(accessToken)
             .contentType("application/json")
     } When {
         patch("/carts/{cartProductId}/options", cartProductId)
@@ -67,7 +67,7 @@ fun requestDeleteCartProduct(
 ): Response {
     return Given {
         log().all()
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .auth().preemptive().oauth2(accessToken)
             .contentType("application/json")
     } When {
         delete("/carts/{cartProductId}", deleteProductId)
@@ -83,7 +83,7 @@ fun requestReadAllCartProducts(
 ): Response {
     return Given {
         log().all()
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .auth().preemptive().oauth2(accessToken)
     } When {
         get("/carts")
     } Then {

--- a/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
+++ b/src/test/kotlin/com/petqua/test/ApiTestConfig.kt
@@ -1,6 +1,6 @@
 package com.petqua.test
 
-import com.petqua.domain.auth.token.AuthTokenProvider
+import com.petqua.presentation.auth.AuthExtractor
 import com.petqua.presentation.auth.AuthResponse
 import com.petqua.test.config.OauthTestConfig
 import io.kotest.core.spec.style.BehaviorSpec
@@ -27,7 +27,8 @@ abstract class ApiTestConfig() : BehaviorSpec() {
     private lateinit var dataCleaner: DataCleaner
 
     @Autowired
-    protected lateinit var authTokenProvider: AuthTokenProvider
+    protected lateinit var authExtractor: AuthExtractor
+
 
     init {
         this.beforeTest {
@@ -39,8 +40,8 @@ abstract class ApiTestConfig() : BehaviorSpec() {
         }
     }
 
-    final fun getMemberIdFromAuthResponse(authResponse: AuthResponse): Long {
-        return authTokenProvider.getAccessTokenClaimsOrThrow(authResponse.accessToken).memberId
+    final fun getMemberIdByAccessToken(accessToken: String): Long {
+        return authExtractor.getAccessTokenClaimsOrThrow(accessToken).memberId
     }
 
     final fun signInAsMember(): AuthResponse {


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #43 

### 📁 작업 설명

- Authorization 에서 Bearer prefix 를 파싱하는 로직을 추가했습니다.
- 관련 테스트도 수정했습니다.
- 홍고의 심부름도 했습니다!

### 기타
- 홍고 코드 이것저것 건드려버렸는데 혹시 제가 의도와 다르게 바꾼 게 있다면 꼭 말씀해주세요!
- import 에서 wildcard 무슨 짓을 해도 다시 변경 되는데 어떻게 하면 좋을까요?