### PR TITLE
feature: Swagger API 명세 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,10 +45,14 @@ dependencies {
 
     // spring boot cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
-    
+
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")
 
+    // test
     testImplementation("io.mockk:mockk:1.13.9")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")

--- a/src/main/kotlin/com/petqua/application/announcement/AnnouncementDtos.kt
+++ b/src/main/kotlin/com/petqua/application/announcement/AnnouncementDtos.kt
@@ -1,10 +1,25 @@
 package com.petqua.application.announcement
 
 import com.petqua.domain.announcement.Announcement
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class AnnouncementResponse(
+    @Schema(
+        description = "배너 id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "공지 제목",
+        example = "[공지] 펫쿠아 안전 운송 시작"
+    )
     val title: String,
+
+    @Schema(
+        description = "링크 URL",
+        example = "link.com"
+    )
     val linkUrl: String,
 ) {
     companion object {

--- a/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
+++ b/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
@@ -1,10 +1,25 @@
 package com.petqua.application.banner.dto
 
 import com.petqua.domain.banner.Banner
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class BannerResponse(
+    @Schema(
+        description = "배너 id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "이미지 URL",
+        example = "image.jpeg"
+    )
     val imageUrl: String,
+
+    @Schema(
+        description = "링크 URL",
+        example = "link.com"
+    )
     val linkUrl: String,
 ) {
     companion object {

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -4,6 +4,7 @@ import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
 import com.petqua.domain.product.Product
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class SaveCartProductCommand(
     val memberId: Long,
@@ -38,17 +39,78 @@ data class DeleteCartProductCommand(
 )
 
 data class CartProductResponse(
+    @Schema(
+        description = "봉달(장바구니) 상품 id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "상품 판매점",
+        example = "S아쿠아"
+    )
     val storeName: String,
+
+    @Schema(
+        description = "상품 id",
+        example = "1"
+    )
     val productId: Long,
+
+    @Schema(
+        description = "상품 이름",
+        example = "알비노 풀레드 아시안 고정구피"
+    )
     val productName: String,
+
+    @Schema(
+        description = "상품 썸네일 이미지",
+        example = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
+    )
     val productThumbnailUrl: String,
+
+    @Schema(
+        description = "상품 가격",
+        example = "30000"
+    )
     val productPrice: Int,
+
+    @Schema(
+        description = "가격 할인율",
+        example = "30"
+    )
     val productDiscountRate: Int,
+
+    @Schema(
+        description = "할인 가격(판매 가격)",
+        example = "21000"
+    )
     val productDiscountPrice: Int,
+
+    @Schema(
+        description = "봉달(장바구니) 수량",
+        example = "1"
+    )
     val quantity: Int,
+
+    @Schema(
+        description = "수컷 여부",
+        example = "true",
+        allowableValues = ["true", "false"]
+    )
     val isMale: Boolean,
+
+    @Schema(
+        description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
+        example = "SAFETY",
+        allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
+    )
     val deliveryMethod: String,
+
+    @Schema(
+        description = "판매 여부(품절 및 삭제 확인)",
+        example = "true"
+    )
     val isOnSale: Boolean,
 ) {
 

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -9,19 +9,79 @@ import com.petqua.domain.product.dto.PADDING_FOR_PAGING
 import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ProductDetailResponse(
+    @Schema(
+        description = "상품 Id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "상품 이름",
+        example = "알비노 풀레드 아시안 고정구피"
+    )
     val name: String,
+
+    @Schema(
+        description = "상품 카테고리",
+        example = "난태생, 송사리과"
+    )
     val category: String,
+
+    @Schema(
+        description = "상품 가격",
+        example = "30000"
+    )
     val price: Int,
+
+    @Schema(
+        description = "상품 판매점",
+        example = "S아쿠아"
+    )
     val storeName: String,
+
+    @Schema(
+        description = "가격 할인율",
+        example = "30"
+    )
     val discountRate: Int,
+
+    @Schema(
+        description = "할인 가격(판매 가격)",
+        example = "21000"
+    )
     val discountPrice: Int,
+
+    @Schema(
+        description = "찜 개수",
+        example = "23"
+    )
     val wishCount: Int,
+
+    @Schema(
+        description = "리뷰 개수",
+        example = "50"
+    )
     val reviewCount: Int,
+
+    @Schema(
+        description = "리뷰 평균 점수",
+        example = "5"
+    )
     val reviewAverageScore: Double,
+
+    @Schema(
+        description = "상품 썸네일 이미지",
+        example = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
+    )
     val thumbnailUrl: String,
+
+    @Schema(
+        description = "상품 상세 설명",
+        example = "귀엽습니다"
+    )
     val description: String,
 ) {
     constructor(product: Product, storeName: String, reviewAverageScore: Double) : this(
@@ -41,9 +101,30 @@ data class ProductDetailResponse(
 }
 
 data class ProductReadQuery(
+    @Schema(
+        description = "상품 조회 출처",
+        example = "HOME_RECOMMENDED",
+        allowableValues = ["HOME_RECOMMENDED", "HOME_NEW_ENROLLMENT"]
+    )
     val sourceType: ProductSourceType = ProductSourceType.NONE,
+
+    @Schema(
+        description = "정렬 기준",
+        defaultValue = "ENROLLMENT_DATE_DESC",
+        allowableValues = ["SALE_PRICE_ASC", "SALE_PRICE_DESC", "REVIEW_COUNT_DESC", "ENROLLMENT_DATE_DESC"]
+    )
     val sorter: Sorter = Sorter.NONE,
+
+    @Schema(
+        description = "마지막으로 조회한 상품의 Id",
+        example = "1"
+    )
     val lastViewedId: Long? = null,
+
+    @Schema(
+        description = "조회할 상품 개수",
+        defaultValue = "20"
+    )
     val limit: Int = LIMIT_CEILING,
 ) {
     fun toReadConditions(): ProductReadCondition {
@@ -57,7 +138,17 @@ data class ProductReadQuery(
 
 data class ProductsResponse(
     val products: List<ProductResponse>,
+
+    @Schema(
+        description = "다음 페이지 존재 여부",
+        example = "true"
+    )
     val hasNextPage: Boolean,
+
+    @Schema(
+        description = "조회 조건에 해당하는 전체 상품 개수",
+        example = "50"
+    )
     val totalProductsCount: Int,
 ) {
     companion object {

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -101,30 +101,9 @@ data class ProductDetailResponse(
 }
 
 data class ProductReadQuery(
-    @Schema(
-        description = "상품 조회 출처",
-        example = "HOME_RECOMMENDED",
-        allowableValues = ["HOME_RECOMMENDED", "HOME_NEW_ENROLLMENT"]
-    )
     val sourceType: ProductSourceType = ProductSourceType.NONE,
-
-    @Schema(
-        description = "정렬 기준",
-        defaultValue = "ENROLLMENT_DATE_DESC",
-        allowableValues = ["SALE_PRICE_ASC", "SALE_PRICE_DESC", "REVIEW_COUNT_DESC", "ENROLLMENT_DATE_DESC"]
-    )
     val sorter: Sorter = Sorter.NONE,
-
-    @Schema(
-        description = "마지막으로 조회한 상품의 Id",
-        example = "1"
-    )
     val lastViewedId: Long? = null,
-
-    @Schema(
-        description = "조회할 상품 개수",
-        defaultValue = "20"
-    )
     val limit: Int = LIMIT_CEILING,
 ) {
     fun toReadConditions(): ProductReadCondition {
@@ -188,5 +167,9 @@ data class ProductKeywordQuery(
 }
 
 data class ProductKeywordResponse(
+    @Schema(
+        description = "추천 검색어",
+        example = "구피"
+    )
     val keyword: String,
 )

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 data class ProductDetailResponse(
     @Schema(
-        description = "상품 Id",
+        description = "상품 id",
         example = "1"
     )
     val id: Long,

--- a/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
@@ -18,7 +18,8 @@ class CorsConfig : WebMvcConfigurer {
             .allowedOrigins(
                 "http://localhost:3000",
                 "https://petqua.co.kr",
-                "http://localhost:5173"
+                "http://localhost:5173",
+                "http://localhost:4173",
             )
             .allowedMethods(
                 OPTIONS.name(),

--- a/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
@@ -15,7 +15,11 @@ class CorsConfig : WebMvcConfigurer {
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3000", "https://petqua.co.kr", "http://localhost:5173")
+            .allowedOrigins(
+                "http://localhost:3000",
+                "https://petqua.co.kr",
+                "http://localhost:5173"
+            )
             .allowedMethods(
                 OPTIONS.name(),
                 GET.name(),

--- a/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/CorsConfig.kt
@@ -21,6 +21,7 @@ class CorsConfig : WebMvcConfigurer {
                 "http://localhost:5173",
                 "http://localhost:4173",
             )
+            .allowedOriginPatterns("https://frontend-git-*-api-blueapple99s-projects.vercel.app")
             .allowedMethods(
                 OPTIONS.name(),
                 GET.name(),

--- a/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-const val ACCESS_TOKEN_SECURITY_SCHEME_KEY = "Access Token (Bearer)"
+const val ACCESS_TOKEN_SECURITY_SCHEME_KEY = "AccessToken(Bearer)"
 
 @Configuration
 class SwaggerConfig {

--- a/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
@@ -1,0 +1,25 @@
+package com.petqua.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .components(Components())
+            .info(info())
+    }
+
+    private fun info(): Info {
+        return Info()
+            .title("펫쿠아 서버 API 명세서")
+            .description("Swagger UI 에서 테스트를 해봅시다")
+            .version("1.0.0")
+    }
+}

--- a/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
@@ -3,8 +3,12 @@ package com.petqua.common.config
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+
+const val ACCESS_TOKEN_SECURITY_SCHEME_KEY = "Access Token (Bearer)"
 
 @Configuration
 class SwaggerConfig {
@@ -12,8 +16,20 @@ class SwaggerConfig {
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
-            .components(Components())
+            .components(authComponents())
             .info(info())
+    }
+
+    private fun authComponents(): Components {
+        return Components().addSecuritySchemes(ACCESS_TOKEN_SECURITY_SCHEME_KEY, accessTokenSecurityScheme())
+    }
+
+    private fun accessTokenSecurityScheme(): SecurityScheme {
+        return SecurityScheme()
+            .name(ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+            .type(HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
     }
 
     private fun info(): Info {

--- a/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
@@ -36,6 +36,7 @@ class SwaggerConfig {
             .type(HTTP)
             .scheme("bearer")
             .bearerFormat("JWT")
+            .description("https://api.petqua.co.kr/auth/Kakao 로그인 후 발급받은 토큰을 입력하세요")
     }
 
     private fun info(): Info {

--- a/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/SwaggerConfig.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -16,8 +17,13 @@ class SwaggerConfig {
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
+            .addServersItem(server())
             .components(authComponents())
             .info(info())
+    }
+
+    private fun server(): Server {
+        return Server().url("/")
     }
 
     private fun authComponents(): Components {

--- a/src/main/kotlin/com/petqua/domain/auth/LoginMember.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/LoginMember.kt
@@ -1,7 +1,9 @@
 package com.petqua.domain.auth
 
 import com.petqua.domain.auth.token.AccessTokenClaims
+import io.swagger.v3.oas.annotations.Hidden
 
+@Hidden
 class LoginMember(
     val memberId: Long,
     val authority: Authority,

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -6,6 +6,7 @@ import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.INVALID_SEARCH_WORD
+import io.swagger.v3.oas.annotations.media.Schema
 
 const val PADDING_FOR_PAGING = 1
 const val LIMIT_CEILING = 20
@@ -49,16 +50,70 @@ data class ProductPaging(
 }
 
 data class ProductResponse(
+    @Schema(
+        description = "상품 Id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "상품 이름",
+        example = "알비노 풀레드 아시안 고정구피"
+    )
     val name: String,
+
+    @Schema(
+        description = "상품 카테고리",
+        example = "난태생, 송사리과"
+    )
     val category: String,
+
+    @Schema(
+        description = "상품 가격",
+        example = "30000"
+    )
     val price: Int,
+
+    @Schema(
+        description = "상품 판매점",
+        example = "S아쿠아"
+    )
     val storeName: String,
+
+    @Schema(
+        description = "가격 할인율",
+        example = "30"
+    )
     val discountRate: Int,
+
+    @Schema(
+        description = "할인 가격(판매 가격)",
+        example = "21000"
+    )
     val discountPrice: Int,
+
+    @Schema(
+        description = "찜 개수",
+        example = "23"
+    )
     val wishCount: Int,
+
+    @Schema(
+        description = "리뷰 개수",
+        example = "50"
+    )
     val reviewCount: Int,
+
+    @Schema(
+        description = "리뷰 평균 점수",
+        example = "5"
+    )
     val reviewAverageScore: Double,
+
+    @Schema(
+        description = "상품 썸네일 이미지",
+        example = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
+    )
     val thumbnailUrl: String,
 ) {
     constructor(product: Product, storeName: String) : this(

--- a/src/main/kotlin/com/petqua/presentation/announcement/AnnouncementController.kt
+++ b/src/main/kotlin/com/petqua/presentation/announcement/AnnouncementController.kt
@@ -2,17 +2,26 @@ package com.petqua.presentation.announcement
 
 import com.petqua.application.announcement.AnnouncementResponse
 import com.petqua.application.announcement.AnnouncementService
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+@Tag(name = "Announcement", description = "공지 관련 API 명세")
 @RequestMapping("/announcements")
 @RestController
 class AnnouncementController(
     private val announcementService: AnnouncementService
 ) {
 
+    @Operation(summary = "공지 조회 API", description = "공지 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "공지 목록 조회 성공")
     @GetMapping
     fun readAll(): ResponseEntity<List<AnnouncementResponse>> {
         val response = announcementService.readAll()

--- a/src/main/kotlin/com/petqua/presentation/announcement/AnnouncementController.kt
+++ b/src/main/kotlin/com/petqua/presentation/announcement/AnnouncementController.kt
@@ -2,17 +2,14 @@ package com.petqua.presentation.announcement
 
 import com.petqua.application.announcement.AnnouncementResponse
 import com.petqua.application.announcement.AnnouncementService
-import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @Tag(name = "Announcement", description = "공지 관련 API 명세")
 @RequestMapping("/announcements")
 @RestController

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -5,6 +5,7 @@ import com.petqua.application.auth.AuthTokenInfo
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.auth.token.AuthToken
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -26,19 +27,21 @@ class AuthController(
     private val authService: AuthService
 ) {
 
+    @Hidden
     @Operation(summary = "리다이렉트 요청 API", description = "Oauth 로그인 페이지로 리다이렉트합니다")
     @ApiResponse(responseCode = "302", description = "리다이렉트 성공")
     @GetMapping("/{oauthServerType}")
     fun redirectToAuthCodeRequestUrl(
         @Schema(description = "Oauth 서버", example = "KAKAO")
         @PathVariable oauthServerType: OauthServerType,
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val redirectUri = authService.getAuthCodeRequestUrl(oauthServerType)
         return ResponseEntity.status(FOUND)
             .location(redirectUri)
             .build()
     }
 
+    @Hidden
     @Operation(summary = "소셜 로그인 API", description = "소셜 로그인을 합니다")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @GetMapping("/login/{oauthServerType}")

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -5,6 +5,10 @@ import com.petqua.application.auth.AuthTokenInfo
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.auth.token.AuthToken
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders.SET_COOKIE
 import org.springframework.http.HttpStatus.FOUND
 import org.springframework.http.ResponseCookie
@@ -15,14 +19,18 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Auth", description = "인증 관련 API 명세")
 @RequestMapping("/auth")
 @RestController
 class AuthController(
     private val authService: AuthService
 ) {
 
+    @Operation(summary = "리다이렉트 요청 API", description = "Oauth 로그인 페이지로 리다이렉트합니다")
+    @ApiResponse(responseCode = "302", description = "리다이렉트 성공")
     @GetMapping("/{oauthServerType}")
     fun redirectToAuthCodeRequestUrl(
+        @Schema(description = "Oauth 서버", example = "KAKAO")
         @PathVariable oauthServerType: OauthServerType,
     ): ResponseEntity<Void> {
         val redirectUri = authService.getAuthCodeRequestUrl(oauthServerType)
@@ -31,9 +39,14 @@ class AuthController(
             .build()
     }
 
+    @Operation(summary = "소셜 로그인 API", description = "소셜 로그인을 합니다")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
     @GetMapping("/login/{oauthServerType}")
     fun login(
+        @Schema(description = "Oauth 서버", example = "KAKAO")
         @PathVariable oauthServerType: OauthServerType,
+
+        @Schema(description = "auth code")
         @RequestParam("code") code: String,
     ): ResponseEntity<AuthResponse> {
         val authTokenInfo = authService.login(oauthServerType, code)
@@ -47,6 +60,8 @@ class AuthController(
             .body(authResponse)
     }
 
+    @Operation(summary = "로그인 유지 API", description = "refresh token으로 access token을 재발급 받습니다")
+    @ApiResponse(responseCode = "200", description = "재발급 성공")
     @GetMapping("/token")
     fun extendLogin(
         @Auth authToken: AuthToken,

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -6,9 +6,6 @@ import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.auth.token.AuthToken
 import io.swagger.v3.oas.annotations.Hidden
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders.SET_COOKIE
 import org.springframework.http.HttpStatus.FOUND
@@ -20,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@Tag(name = "Auth", description = "인증 관련 API 명세")
+@Tag(name = "Auth", description = "인증 관련 API 명세(Swagger에서 테스트할 수 없어 숨김 처리 되었습니다.)")
 @RequestMapping("/auth")
 @RestController
 class AuthController(
@@ -28,11 +25,8 @@ class AuthController(
 ) {
 
     @Hidden
-    @Operation(summary = "리다이렉트 요청 API", description = "Oauth 로그인 페이지로 리다이렉트합니다")
-    @ApiResponse(responseCode = "302", description = "리다이렉트 성공")
     @GetMapping("/{oauthServerType}")
     fun redirectToAuthCodeRequestUrl(
-        @Schema(description = "Oauth 서버", example = "KAKAO")
         @PathVariable oauthServerType: OauthServerType,
     ): ResponseEntity<Unit> {
         val redirectUri = authService.getAuthCodeRequestUrl(oauthServerType)
@@ -42,14 +36,9 @@ class AuthController(
     }
 
     @Hidden
-    @Operation(summary = "소셜 로그인 API", description = "소셜 로그인을 합니다")
-    @ApiResponse(responseCode = "200", description = "로그인 성공")
     @GetMapping("/login/{oauthServerType}")
     fun login(
-        @Schema(description = "Oauth 서버", example = "KAKAO")
         @PathVariable oauthServerType: OauthServerType,
-
-        @Schema(description = "auth code")
         @RequestParam("code") code: String,
     ): ResponseEntity<AuthResponse> {
         val authTokenInfo = authService.login(oauthServerType, code)
@@ -63,8 +52,7 @@ class AuthController(
             .body(authResponse)
     }
 
-    @Operation(summary = "로그인 유지 API", description = "refresh token으로 access token을 재발급 받습니다")
-    @ApiResponse(responseCode = "200", description = "재발급 성공")
+    @Hidden
     @GetMapping("/token")
     fun extendLogin(
         @Auth authToken: AuthToken,

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
@@ -1,8 +1,5 @@
 package com.petqua.presentation.auth
 
-import io.swagger.v3.oas.annotations.media.Schema
-
 data class AuthResponse(
-    @Schema(description = "access token", example = "xxx.yyy.zzz")
     val accessToken: String,
 )

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
@@ -1,5 +1,8 @@
 package com.petqua.presentation.auth
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class AuthResponse(
+    @Schema(description = "access token", example = "xxx.yyy.zzz")
     val accessToken: String,
 )

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -2,17 +2,26 @@ package com.petqua.presentation.banner
 
 import com.petqua.application.banner.BannerService
 import com.petqua.application.banner.dto.BannerResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+@Tag(name = "Banner", description = "배너 관련 API 명세")
 @RequestMapping("/banners")
 @RestController
 class BannerController(
     private val bannerService: BannerService
 ) {
 
+    @Operation(summary = "배너 조회 API", description = "배너 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "배너 목록 조회 성공")
     @GetMapping
     fun readAll(): ResponseEntity<List<BannerResponse>> {
         val response = bannerService.readAll()

--- a/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
+++ b/src/main/kotlin/com/petqua/presentation/banner/BannerController.kt
@@ -2,17 +2,14 @@ package com.petqua.presentation.banner
 
 import com.petqua.application.banner.BannerService
 import com.petqua.application.banner.dto.BannerResponse
-import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @Tag(name = "Banner", description = "배너 관련 API 명세")
 @RequestMapping("/banners")
 @RestController

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -4,10 +4,15 @@ import com.petqua.application.cart.CartProductService
 import com.petqua.application.cart.dto.DeleteCartProductCommand
 import com.petqua.application.cart.dto.CartProductResponse
 import com.petqua.application.product.dto.ProductDetailResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,12 +24,16 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+@Tag(name = "Cart", description = "봉달(장바구니) 관련 API 명세")
 @RequestMapping("/carts")
 @RestController
 class CartProductController(
     private val cartProductService: CartProductService,
 ) {
 
+    @Operation(summary = "봉달 추가 API", description = "상품을 봉달에 추가합니다")
+    @ApiResponse(responseCode = "201", description = "봉달 추가 성공")
     @PostMapping
     fun save(
         @Auth loginMember: LoginMember,
@@ -39,6 +48,8 @@ class CartProductController(
         return ResponseEntity.created(location).build()
     }
 
+    @Operation(summary = "봉달 옵션 수정 API", description = "봉달에 있는 상품의 옵션을 변경합니다")
+    @ApiResponse(responseCode = "204", description = "봉달 상품 옵션 변경 성공")
     @PatchMapping("/{cartProductId}/options")
     fun updateOptions(
         @Auth loginMember: LoginMember,

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -1,8 +1,8 @@
 package com.petqua.presentation.cart
 
 import com.petqua.application.cart.CartProductService
-import com.petqua.application.cart.dto.DeleteCartProductCommand
 import com.petqua.application.cart.dto.CartProductResponse
+import com.petqua.application.cart.dto.DeleteCartProductCommand
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
@@ -10,6 +10,7 @@ import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -61,9 +62,12 @@ class CartProductController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "봉달 삭제 API", description = "상품을 봉달에서 삭제합니다")
+    @ApiResponse(responseCode = "204", description = "봉달 삭제 성공")
     @DeleteMapping("/{cartProductId}")
     fun delete(
         @Auth loginMember: LoginMember,
+        @Schema(description = "봉달 상품 id", example = "1")
         @PathVariable cartProductId: Long
     ): ResponseEntity<Void> {
         val command = DeleteCartProductCommand(
@@ -74,6 +78,8 @@ class CartProductController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "봉달 목록 조회 API", description = "봉달 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "봉달 목록 조회 성공")
     @GetMapping
     fun readAll(
         @Auth loginMember: LoginMember,

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -4,11 +4,33 @@ import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.DeliveryMethod
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class SaveCartProductRequest(
+    @Schema(
+        description = "상품 id",
+        example = "1"
+    )
     val productId: Long,
+
+    @Schema(
+        description = "상품 개수",
+        example = "1"
+    )
     val quantity: Int,
+
+    @Schema(
+        description = "수컷 여부",
+        example = "true",
+        allowableValues = ["true", "false"]
+    )
     val isMale: Boolean,
+
+    @Schema(
+        description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
+        example = "COMMON",
+        allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
+    )
     val deliveryMethod: String,
 ) {
 
@@ -24,8 +46,24 @@ data class SaveCartProductRequest(
 }
 
 data class UpdateCartProductOptionRequest(
+    @Schema(
+        description = "상품 개수",
+        example = "1"
+    )
     val quantity: Int,
+
+    @Schema(
+        description = "수컷 여부",
+        example = "true",
+        allowableValues = ["true", "false"]
+    )
     val isMale: Boolean,
+
+    @Schema(
+        description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
+        example = "COMMON",
+        allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
+    )
     val deliveryMethod: String,
 ) {
 

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -47,7 +47,7 @@ data class SaveCartProductRequest(
 
 data class UpdateCartProductOptionRequest(
     @Schema(
-        description = "상품 개수",
+        description = "봉달(장바구니) 수량",
         example = "1"
     )
     val quantity: Int,

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -4,13 +4,11 @@ import com.petqua.application.product.ProductService
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.application.product.dto.ProductKeywordResponse
 import com.petqua.application.product.dto.ProductsResponse
-import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.presentation.product.dto.ProductKeywordRequest
 import com.petqua.presentation.product.dto.ProductReadRequest
 import com.petqua.presentation.product.dto.ProductSearchRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,7 +16,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @Tag(name = "Product", description = "상품 관련 API 명세")
 @RequestMapping("/products")
 @RestController

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -18,16 +18,16 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@Tag(name = "Product", description = "상품 관련 API 명세")
 @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+@Tag(name = "Product", description = "상품 관련 API 명세")
 @RequestMapping("/products")
 @RestController
 class ProductController(
     private val productService: ProductService
 ) {
 
-    @Operation(summary = "상품 상세 조회 API", description = "상품의 상세 정보를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공.")
+    @Operation(summary = "상품 상세 조회 API", description = "상품의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공")
     @GetMapping("/{productId}")
     fun readById(
         @PathVariable productId: Long
@@ -36,8 +36,8 @@ class ProductController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(summary = "상품 조건 조회 API", description = "상품을 조건에 따라 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "상품 조건 조회 성공.")
+    @Operation(summary = "상품 조건 조회 API", description = "상품을 조건에 따라 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상품 조건 조회 성공")
     @GetMapping
     fun readAll(
         request: ProductReadRequest

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -43,6 +43,8 @@ class ProductController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "상품 검색 API", description = "검색으로 상품을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상품 검색 조회 성공")
     @GetMapping("/search")
     fun readBySearch(
         request: ProductSearchRequest
@@ -51,6 +53,8 @@ class ProductController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "상품 추천 검색어(자동완성) 조회 API", description = "추천 검색어를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "추천 검색어 조회 성공")
     @GetMapping("/keywords")
     fun readAutoCompleteKeywords(
         request: ProductKeywordRequest

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -4,21 +4,30 @@ import com.petqua.application.product.ProductService
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.application.product.dto.ProductKeywordResponse
 import com.petqua.application.product.dto.ProductsResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.presentation.product.dto.ProductKeywordRequest
 import com.petqua.presentation.product.dto.ProductReadRequest
 import com.petqua.presentation.product.dto.ProductSearchRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Product", description = "상품 관련 API 명세")
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @RequestMapping("/products")
 @RestController
 class ProductController(
     private val productService: ProductService
 ) {
 
+    @Operation(summary = "상품 상세 조회 API", description = "상품의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공.")
     @GetMapping("/{productId}")
     fun readById(
         @PathVariable productId: Long
@@ -27,6 +36,8 @@ class ProductController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "상품 조건 조회 API", description = "상품을 조건에 따라 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "상품 조건 조회 성공.")
     @GetMapping
     fun readAll(
         request: ProductReadRequest

--- a/src/main/kotlin/com/petqua/presentation/product/WishProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/WishProductController.kt
@@ -1,8 +1,13 @@
 package com.petqua.presentation.product
 
 import com.petqua.application.product.WishProductService
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -10,12 +15,16 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+@Tag(name = "WishProduct", description = "찜 관련 API 명세")
 @RequestMapping("/products/wishes")
 @RestController
 class WishProductController(
     private val wishProductService: WishProductService
 ) {
 
+    @Operation(summary = "찜 상태 변경 API", description = "찜 상태를 변경합니다")
+    @ApiResponse(responseCode = "204", description = "찜 상태 변경 성공")
     @PostMapping
     fun update(
         @Auth loginMember: LoginMember,
@@ -28,6 +37,8 @@ class WishProductController(
             .build()
     }
 
+    @Operation(summary = "찜 상품 목록 조회 API", description = "찜한 상품 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "찜 상품 목록 조회 성공")
     @GetMapping
     fun readAll(
         @Auth loginMember: LoginMember,

--- a/src/main/kotlin/com/petqua/presentation/product/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/WishProductDtos.kt
@@ -3,12 +3,17 @@ package com.petqua.presentation.product
 import com.petqua.application.product.dto.ReadAllWishProductCommand
 import com.petqua.application.product.dto.UpdateWishCommand
 import com.petqua.domain.product.Product
+import io.swagger.v3.oas.annotations.media.Schema
 
 private const val PADDING_FOR_PAGING = 1
 private const val LIMIT_CEILING = 20
 private const val DEFAULT_LAST_VIEWED_ID = -1L
 
 data class UpdateWishRequest(
+    @Schema(
+        description = "상품 id",
+        example = "1"
+    )
     val productId: Long,
 ) {
     fun toCommand(memberId: Long): UpdateWishCommand {
@@ -20,7 +25,16 @@ data class UpdateWishRequest(
 }
 
 data class ReadAllWishProductRequest(
+    @Schema(
+        description = "마지막으로 조회한 찜의 Id",
+        example = "1"
+    )
     val lastViewedId: Long? = null,
+
+    @Schema(
+        description = "조회할 찜 개수",
+        defaultValue = "20"
+    )
     val limit: Int = LIMIT_CEILING,
 ) {
 
@@ -36,7 +50,17 @@ data class ReadAllWishProductRequest(
 
 data class WishProductsResponse(
     val wishProducts: List<WishProductResponse>,
+
+    @Schema(
+        description = "다음 페이지 존재 여부",
+        example = "true"
+    )
     val hasNextPage: Boolean,
+
+    @Schema(
+        description = "조회 조건에 해당하는 전체 상품 개수",
+        example = "50"
+    )
     val totalWishProductsCount: Int,
 ) {
     companion object {
@@ -55,18 +79,82 @@ data class WishProductsResponse(
 }
 
 data class WishProductResponse(
+    @Schema(
+        description = "찜 Id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "상품 Id",
+        example = "1"
+    )
     val productId: Long,
+
+    @Schema(
+        description = "상품 이름",
+        example = "알비노 풀레드 아시안 고정구피"
+    )
     val name: String,
+
+    @Schema(
+        description = "상품 카테고리",
+        example = "난태생, 송사리과"
+    )
     val category: String,
+
+    @Schema(
+        description = "상품 가격",
+        example = "30000"
+    )
     val price: Int,
+
+    @Schema(
+        description = "상품 판매점",
+        example = "S아쿠아"
+    )
     val storeName: String,
+
+    @Schema(
+        description = "가격 할인율",
+        example = "30"
+    )
     val discountRate: Int,
+
+    @Schema(
+        description = "할인 가격(판매 가격)",
+        example = "21000"
+    )
     val discountPrice: Int,
+
+    @Schema(
+        description = "찜 개수",
+        example = "23"
+    )
     val wishCount: Int,
+
+    @Schema(
+        description = "리뷰 개수",
+        example = "50"
+    )
     val reviewCount: Int,
+
+    @Schema(
+        description = "리뷰 평균 점수",
+        example = "5"
+    )
     val reviewAverageScore: Double,
+
+    @Schema(
+        description = "상품 썸네일 이미지",
+        example = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
+    )
     val thumbnailUrl: String,
+
+    @Schema(
+        description = "상품 삭제 여부",
+        example = "false"
+    )
     val isDeletedProduct: Boolean,
 ) {
     constructor(wishProductId: Long, product: Product, storeName: String) : this(

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
@@ -6,11 +6,33 @@ import com.petqua.application.product.dto.ProductSearchQuery
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import com.petqua.domain.product.dto.LIMIT_CEILING
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ProductReadRequest(
+    @Schema(
+        description = "상품 조회 출처",
+        example = "HOME_RECOMMENDED",
+        allowableValues = ["HOME_RECOMMENDED", "HOME_NEW_ENROLLMENT"]
+    )
     val sourceType: ProductSourceType = ProductSourceType.NONE,
+
+    @Schema(
+        description = "정렬 기준",
+        defaultValue = "ENROLLMENT_DATE_DESC",
+        allowableValues = ["SALE_PRICE_ASC", "SALE_PRICE_DESC", "REVIEW_COUNT_DESC", "ENROLLMENT_DATE_DESC"]
+    )
     val sorter: Sorter = Sorter.NONE,
+
+    @Schema(
+        description = "마지막으로 조회한 상품의 Id",
+        example = "1"
+    )
     val lastViewedId: Long? = null,
+
+    @Schema(
+        description = "조회할 상품 개수",
+        defaultValue = "20"
+    )
     val limit: Int = LIMIT_CEILING,
 ) {
 
@@ -25,8 +47,22 @@ data class ProductReadRequest(
 }
 
 data class ProductSearchRequest(
+    @Schema(
+        description = "검색어",
+        example = "구피"
+    )
     val word: String = "",
+
+    @Schema(
+        description = "마지막으로 조회한 상품의 Id",
+        example = "1"
+    )
     val lastViewedId: Long? = null,
+
+    @Schema(
+        description = "조회할 상품 개수",
+        defaultValue = "20"
+    )
     val limit: Int = LIMIT_CEILING,
 ) {
 
@@ -40,7 +76,16 @@ data class ProductSearchRequest(
 }
 
 data class ProductKeywordRequest(
+    @Schema(
+        description = "마지막으로 조회한 상품의 Id",
+        example = "1"
+    )
     val word: String = "",
+
+    @Schema(
+        description = "조회할 상품 개수",
+        defaultValue = "20"
+    )
     val limit: Int = LIMIT_CEILING,
 ) {
 


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #30 

### 📁 작업 설명

- Swagger API 명세 설정 추가했습니다!

### 참고
Swagger에서 Auth 관련 API 들은 테스트할 수 없거나 힘듭니다. 따라서 Auth 관련 API 들은 Hidden 처리했습니다.

#### 1. `/auth/Kakao`
redirect 페이지를 로드할 수 없습니다. CORS 에러를 마주하게 됩니다.
![image](https://github.com/petqua/backend/assets/106813090/720724ae-97ba-4799-b744-5e147fe876de)

#### 2. `/auth/login/Kakao`
카카오에서 전달해주는 auth code를 받을 수 없습니다.

#### 3. `/auth/token`
Swagger UI에서 refreshToken 을 서버에게 cookie로 전달할 수 없습니다. 다음 자료를 참고해주세요.

- https://github.com/tiangolo/fastapi/issues/880
- https://swagger.io/docs/specification/authentication/cookie-authentication/

> Note for Swagger UI and Swagger Editor users: Cookie authentication is currently not supported for "try it out" requests due to browser security restrictions. See [this issue](https://github.com/swagger-api/swagger-js/issues/1163) for more information. [SwaggerHub](https://swagger.io/tools/swaggerhub/) does not have this limitation.

### 기타
- 각자 localhost 에서 테스트 해보셔도 좋을 것 같습니다!