### PR TITLE
refactor: Auth Swagger 명세 다시 추가

### DIFF
--- a/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthDtos.kt
@@ -1,5 +1,8 @@
 package com.petqua.presentation.auth
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class AuthResponse(
+    @Schema(description = "access token", example = "xxx.yyy.zzz")
     val accessToken: String,
 )


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #58 

### 📁 작업 설명

- 프론트엔드 요청에 의해 Swagger에 Auth 관련 API 명세를 다시 추가했습니다.