### PR TITLE
feature: 쿼리 카운터 구현

### DIFF
--- a/src/main/kotlin/com/petqua/common/query/ConnectionProxyHandler.kt
+++ b/src/main/kotlin/com/petqua/common/query/ConnectionProxyHandler.kt
@@ -1,0 +1,35 @@
+package com.petqua.common.query
+
+import org.aopalliance.intercept.MethodInterceptor
+import org.aopalliance.intercept.MethodInvocation
+import org.springframework.aop.framework.ProxyFactory
+
+private const val HIKARY_PROXY_CONNECTION = "HikariProxyConnection"
+private const val PREPARED_STATEMENT = "prepareStatement"
+
+class ConnectionProxyHandler(
+    private val connection: Any,
+    private val queryInfo: QueryInfo,
+) : MethodInterceptor {
+
+    override fun invoke(invocation: MethodInvocation): Any? {
+        val result = invocation.proceed()
+        if (result != null && isPreparedStatement(invocation)) {
+            queryInfo.increaseCount()
+        }
+        return result
+    }
+
+    private fun isPreparedStatement(invocation: MethodInvocation): Boolean {
+        val targetObject = invocation.getThis() ?: return false
+        val targetClass: Class<*> = targetObject.javaClass
+        val targetMethod = invocation.method
+        return targetClass.getName().contains(HIKARY_PROXY_CONNECTION) && targetMethod.name == PREPARED_STATEMENT
+    }
+
+    fun getProxy(): Any {
+        val proxyFactory = ProxyFactory(connection)
+        proxyFactory.addAdvice(this)
+        return proxyFactory.proxy
+    }
+}

--- a/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
+++ b/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
@@ -14,15 +14,16 @@ class PreparedStatementProxyHandler(
 
     @Nullable
     override operator fun invoke(@Nonnull invocation: MethodInvocation): Any? {
+        var result: Any?
+        val executionTime = measureTimeMillis {
+            result = invocation.proceed()
+        }
+
         val method = invocation.method
         if (method.name.contains(EXECUTE)) {
-            return measureTimeMillis {
-                invocation.proceed()
-            }.also {
-                queryInfo.time += it
-                queryInfo.increaseCount()
-            }
+            queryInfo.time.plus(executionTime)
+            queryInfo.increaseCount()
         }
-        return invocation.proceed()
+        return result;
     }
 }

--- a/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
+++ b/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
@@ -1,0 +1,27 @@
+package com.petqua.common.query
+
+import jakarta.annotation.Nonnull
+import jakarta.annotation.Nullable
+import org.aopalliance.intercept.MethodInterceptor
+import org.aopalliance.intercept.MethodInvocation
+
+private const val EXECUTE = "execute"
+
+class PreparedStatementProxyHandler(
+    private val queryInfo: QueryInfo,
+) : MethodInterceptor {
+
+    @Nullable
+    override operator fun invoke(@Nonnull invocation: MethodInvocation): Any? {
+        val method = invocation.method
+        if (method.name.contains(EXECUTE)) {
+            val startTime = System.currentTimeMillis()
+            val result = invocation.proceed()
+            val endTime = System.currentTimeMillis()
+            queryInfo.time += endTime - startTime
+            queryInfo.increaseCount()
+            return result
+        }
+        return invocation.proceed()
+    }
+}

--- a/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
+++ b/src/main/kotlin/com/petqua/common/query/PreparedStatementProxyHandler.kt
@@ -4,6 +4,7 @@ import jakarta.annotation.Nonnull
 import jakarta.annotation.Nullable
 import org.aopalliance.intercept.MethodInterceptor
 import org.aopalliance.intercept.MethodInvocation
+import kotlin.system.measureTimeMillis
 
 private const val EXECUTE = "execute"
 
@@ -15,12 +16,12 @@ class PreparedStatementProxyHandler(
     override operator fun invoke(@Nonnull invocation: MethodInvocation): Any? {
         val method = invocation.method
         if (method.name.contains(EXECUTE)) {
-            val startTime = System.currentTimeMillis()
-            val result = invocation.proceed()
-            val endTime = System.currentTimeMillis()
-            queryInfo.time += endTime - startTime
-            queryInfo.increaseCount()
-            return result
+            return measureTimeMillis {
+                invocation.proceed()
+            }.also {
+                queryInfo.time += it
+                queryInfo.increaseCount()
+            }
         }
         return invocation.proceed()
     }

--- a/src/main/kotlin/com/petqua/common/query/QueryCounterAop.kt
+++ b/src/main/kotlin/com/petqua/common/query/QueryCounterAop.kt
@@ -31,7 +31,7 @@ class QueryCounterAop {
         val request = attributes?.request
         request?.let {
             val queryInfo = queryInfoStorage.getOrSet { QueryInfo() }
-            log.info("METHOD: ${request.method}, URI: ${request.requestURI}, QUERY_COUNT: ${queryInfo.count}, QUERY_TIME: ${queryInfo.time}")
+            log.info("METHOD: ${request.method}, URI: ${request.requestURI}, QUERY_COUNT: ${queryInfo.count}, QUERY_TIME: ${queryInfo.time}ms")
         }
         queryInfoStorage.remove()
     }

--- a/src/main/kotlin/com/petqua/common/query/QueryCounterAop.kt
+++ b/src/main/kotlin/com/petqua/common/query/QueryCounterAop.kt
@@ -1,0 +1,43 @@
+package com.petqua.common.query
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.After
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+
+@Aspect
+@Component
+class QueryCounterAop {
+
+    private val log = LoggerFactory.getLogger(QueryCounterAop::class.java)
+    private val queryInfoStorage = ThreadLocal<QueryInfo>()
+
+    @Around("execution( * javax.sql.DataSource.getConnection())")
+    fun getProxyConnection(joinPoint: ProceedingJoinPoint): Any {
+        val connection = joinPoint.proceed()
+        return ConnectionProxyHandler(connection, getQueryInfo()).getProxy()
+    }
+
+    @After("within(@org.springframework.web.bind.annotation.RestController *)")
+    fun logQueryInfo() {
+        val attributes = RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+        val request = attributes?.request
+        request?.let {
+            val queryInfo = getQueryInfo()
+            log.info("METHOD: ${request.method}, URI: ${request.requestURI}, $queryInfo")
+        }
+        queryInfoStorage.remove()
+    }
+
+    private fun getQueryInfo(): QueryInfo {
+        if (queryInfoStorage.get() == null) {
+            queryInfoStorage.set(QueryInfo())
+        }
+        return queryInfoStorage.get()
+    }
+}

--- a/src/main/kotlin/com/petqua/common/query/QueryInfo.kt
+++ b/src/main/kotlin/com/petqua/common/query/QueryInfo.kt
@@ -1,0 +1,10 @@
+package com.petqua.common.query
+
+data class QueryInfo(
+    var count: Int = 0,
+) {
+
+    fun increaseCount() {
+        count++
+    }
+}

--- a/src/main/kotlin/com/petqua/common/query/QueryInfo.kt
+++ b/src/main/kotlin/com/petqua/common/query/QueryInfo.kt
@@ -2,6 +2,7 @@ package com.petqua.common.query
 
 data class QueryInfo(
     var count: Int = 0,
+    var time: Long = 0L,
 ) {
 
     fun increaseCount() {


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #57

### 📁 작업 설명

- 설명
하나의 API요청에서 발생한 쿼리 개수와 소요시간을 측정해서 로깅합니다.
예시 : `METHOD: GET, URI: products/wishes, QUERY_COUNT: 3, QUERY_TIME: 7`


### 기타
예전에 쿼리카운터쓸 때 소요시간까지 로깅하는게 좋았어서 추가했습니다...! 
근데 소요시간 측정때문에 PreparedStatementProxyHandler가 추가됐네요...ㅎㅎ
(쿼리 개수만 카운팅 할 때 코드 참고: 65d2782782c6953a0896e0488f2e1be76458598e)
소요시간 로그에서 빼고 싶으시면 말씀해주십시오~~~