### PR TITLE
feature: 상품 후기 조회 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/product/WishProductService.kt
+++ b/src/main/kotlin/com/petqua/application/product/WishProductService.kt
@@ -13,7 +13,7 @@ import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
-import com.petqua.presentation.product.WishProductsResponse
+import com.petqua.presentation.product.dto.WishProductsResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -1,12 +1,13 @@
 package com.petqua.application.product.dto
 
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
-import com.petqua.domain.product.dto.PRODUCT_PADDING_FOR_PAGING
-import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import io.swagger.v3.oas.annotations.media.Schema
@@ -103,15 +104,15 @@ data class ProductDetailResponse(
 data class ProductReadQuery(
     val sourceType: ProductSourceType = ProductSourceType.NONE,
     val sorter: Sorter = Sorter.NONE,
-    val lastViewedId: Long? = null,
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
     fun toReadConditions(): ProductReadCondition {
         return ProductReadCondition.toCondition(sourceType, sorter)
     }
 
-    fun toPaging(): ProductPaging {
-        return ProductPaging.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPagingRequest {
+        return CursorBasedPagingRequest.of(lastViewedId, limit)
     }
 }
 
@@ -133,7 +134,7 @@ data class ProductsResponse(
     companion object {
         fun of(products: List<ProductResponse>, limit: Int, totalProductsCount: Int): ProductsResponse {
             return if (products.size > limit) {
-                ProductsResponse(products.dropLast(PRODUCT_PADDING_FOR_PAGING), hasNextPage = true, totalProductsCount)
+                ProductsResponse(products.dropLast(PADDING_FOR_HAS_NEXT_PAGE), hasNextPage = true, totalProductsCount)
             } else {
                 ProductsResponse(products, hasNextPage = false, totalProductsCount)
             }
@@ -143,22 +144,22 @@ data class ProductsResponse(
 
 data class ProductSearchQuery(
     val word: String = "",
-    val lastViewedId: Long? = null,
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toSearchCondition(): ProductReadCondition {
         return ProductReadCondition.toSearchCondition(word)
     }
 
-    fun toPaging(): ProductPaging {
-        return ProductPaging.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPagingRequest {
+        return CursorBasedPagingRequest.of(lastViewedId, limit)
     }
 }
 
 data class ProductKeywordQuery(
     val word: String = "",
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toProductKeyword(): ProductKeyword {

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -1,6 +1,6 @@
 package com.petqua.application.product.dto
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
@@ -111,8 +111,8 @@ data class ProductReadQuery(
         return ProductReadCondition.toCondition(sourceType, sorter)
     }
 
-    fun toPaging(): CursorBasedPagingRequest {
-        return CursorBasedPagingRequest.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPaging {
+        return CursorBasedPaging.of(lastViewedId, limit)
     }
 }
 
@@ -152,8 +152,8 @@ data class ProductSearchQuery(
         return ProductReadCondition.toSearchCondition(word)
     }
 
-    fun toPaging(): CursorBasedPagingRequest {
-        return CursorBasedPagingRequest.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPaging {
+        return CursorBasedPaging.of(lastViewedId, limit)
     }
 }
 

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -4,8 +4,8 @@ import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.LIMIT_CEILING
-import com.petqua.domain.product.dto.PADDING_FOR_PAGING
+import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
+import com.petqua.domain.product.dto.PRODUCT_PADDING_FOR_PAGING
 import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
@@ -104,7 +104,7 @@ data class ProductReadQuery(
     val sourceType: ProductSourceType = ProductSourceType.NONE,
     val sorter: Sorter = Sorter.NONE,
     val lastViewedId: Long? = null,
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
     fun toReadConditions(): ProductReadCondition {
         return ProductReadCondition.toCondition(sourceType, sorter)
@@ -133,7 +133,7 @@ data class ProductsResponse(
     companion object {
         fun of(products: List<ProductResponse>, limit: Int, totalProductsCount: Int): ProductsResponse {
             return if (products.size > limit) {
-                ProductsResponse(products.dropLast(PADDING_FOR_PAGING), hasNextPage = true, totalProductsCount)
+                ProductsResponse(products.dropLast(PRODUCT_PADDING_FOR_PAGING), hasNextPage = true, totalProductsCount)
             } else {
                 ProductsResponse(products, hasNextPage = false, totalProductsCount)
             }
@@ -144,7 +144,7 @@ data class ProductsResponse(
 data class ProductSearchQuery(
     val word: String = "",
     val lastViewedId: Long? = null,
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     fun toSearchCondition(): ProductReadCondition {
@@ -158,7 +158,7 @@ data class ProductSearchQuery(
 
 data class ProductKeywordQuery(
     val word: String = "",
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     fun toProductKeyword(): ProductKeyword {

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -1,9 +1,11 @@
 package com.petqua.application.product.dto
 
-import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
-import com.petqua.domain.product.dto.REVIEW_PADDING_FOR_PAGING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import io.swagger.v3.oas.annotations.media.Schema
@@ -15,8 +17,8 @@ data class ProductReviewReadQuery(
     val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
     val score: Int? = null,
     val photoOnly: Boolean = false,
-    val lastViewedId: Long = -1,
-    val limit: Int = 20,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toCondition(): ProductReviewReadCondition {
@@ -28,8 +30,8 @@ data class ProductReviewReadQuery(
         )
     }
 
-    fun toPaging(): ProductReviewPaging {
-        return ProductReviewPaging.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPagingRequest {
+        return CursorBasedPagingRequest.of(lastViewedId, limit)
     }
 }
 
@@ -45,7 +47,7 @@ data class ProductReviewsResponse(
     companion object {
         fun of(products: List<ProductReviewResponse>, limit: Int): ProductReviewsResponse {
             return if (products.size > limit) {
-                ProductReviewsResponse(products.dropLast(REVIEW_PADDING_FOR_PAGING), hasNextPage = true)
+                ProductReviewsResponse(products.dropLast(PADDING_FOR_HAS_NEXT_PAGE), hasNextPage = true)
             } else {
                 ProductReviewsResponse(products, hasNextPage = false)
             }

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -3,11 +3,10 @@ package com.petqua.application.product.dto
 import com.petqua.domain.product.dto.ProductReviewPaging
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
+import com.petqua.domain.product.dto.REVIEW_PADDING_FOR_PAGING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import java.time.LocalDateTime
-
-private const val REVIEW_PADDING_FOR_PAGING = 1
 
 data class ProductReviewReadQuery(
     val productId: Long,

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -1,6 +1,6 @@
 package com.petqua.application.product.dto
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
@@ -30,8 +30,8 @@ data class ProductReviewReadQuery(
         )
     }
 
-    fun toPaging(): CursorBasedPagingRequest {
-        return CursorBasedPagingRequest.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPaging {
+        return CursorBasedPaging.of(lastViewedId, limit)
     }
 }
 

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -34,7 +34,7 @@ data class ProductReviewReadQuery(
 }
 
 data class ProductReviewsResponse(
-    val products: List<ProductReviewResponse>,
+    val productReviews: List<ProductReviewResponse>,
 
     @Schema(
         description = "다음 페이지 존재 여부",

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -6,6 +6,7 @@ import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import com.petqua.domain.product.dto.REVIEW_PADDING_FOR_PAGING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class ProductReviewReadQuery(
@@ -34,6 +35,11 @@ data class ProductReviewReadQuery(
 
 data class ProductReviewsResponse(
     val products: List<ProductReviewResponse>,
+
+    @Schema(
+        description = "다음 페이지 존재 여부",
+        example = "true"
+    )
     val hasNextPage: Boolean,
 ) {
     companion object {
@@ -48,19 +54,88 @@ data class ProductReviewsResponse(
 }
 
 data class ProductReviewResponse(
+    @Schema(
+        description = "상품 후기의 id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "상품 id",
+        example = "1"
+    )
     val productId: Long,
+
+    @Schema(
+        description = "상품 후기 평점",
+        example = "5"
+    )
     val score: Int,
+
+    @Schema(
+        description = "상품 후기 내용",
+        example = "아주 좋네요"
+    )
     val content: String,
+
+    @Schema(
+        description = "상품 후기 추천 수",
+        example = "3"
+    )
     val recommendCount: Int,
+
+    @Schema(
+        description = "상품 후기에 사진이 있는지 여부",
+        example = "true"
+    )
     val hasPhotos: Boolean,
+
+    @Schema(
+        description = "상품 후기 작성일",
+        example = "2021-08-01T00:00:00"
+    )
     val createdAt: LocalDateTime,
+
+    @Schema(
+        description = "상품 후기 작성자 id",
+        example = "1"
+    )
     val reviewerId: Long,
+
+    @Schema(
+        description = "상품 후기 작성자 이름",
+        example = "홍길동"
+    )
     val reviewerName: String,
+
+    @Schema(
+        description = "상품 후기 작성자 프로필 이미지 url",
+        example = "http:/docs.petqua.co.kr/profile.jpg"
+    )
     val reviewerProfileImageUrl: String?,
+
+    @Schema(
+        description = "상품 후기 작성자 수조 개수",
+        example = "3"
+    )
     val reviewerFishBowlCount: Int,
+
+    @Schema(
+        description = "상품 후기 작성자 회원 가입 연차",
+        example = "3"
+    )
     val reviewerYears: Int,
+
+    @Schema(
+        description = "상품 후기 추천 여부",
+        example = "true"
+    )
     val recommended: Boolean = false, // TODO: 추천 작업 시 추가 예정
+
+    @Schema(
+        description = "상품 후기에 등록된 이미지 url 리스트",
+        example = "[\"http:/docs.petqua.co.kr/review1.jpg\", \"http:/docs.petqua.co.kr/review2.jpg\"]"
+    )
     val images: List<String>,
 ) {
     constructor(productReviewWithMemberResponse: ProductReviewWithMemberResponse, images: List<String>) : this(

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -1,0 +1,82 @@
+package com.petqua.application.product.dto
+
+import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
+import com.petqua.domain.product.review.ProductReviewSorter
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import java.time.LocalDateTime
+
+private const val REVIEW_PADDING_FOR_PAGING = 1
+
+data class ProductReviewReadQuery(
+    val productId: Long,
+    val memberId: Long?,
+    val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
+    val score: Int?,
+    val photoOnly: Boolean = false,
+    val lastViewedId: Long,
+    val limit: Int,
+) {
+
+    fun toCondition(): ProductReviewReadCondition {
+        return ProductReviewReadCondition(
+            productId = productId,
+            sorter = sorter,
+            score = score,
+            photoOnly = photoOnly,
+        )
+    }
+
+    fun toPaging(): ProductReviewPaging {
+        return ProductReviewPaging.of(lastViewedId, limit)
+    }
+}
+
+data class ProductReviewsResponse(
+    val products: List<ProductReviewResponse>,
+    val hasNextPage: Boolean,
+) {
+    companion object {
+        fun of(products: List<ProductReviewResponse>, limit: Int): ProductReviewsResponse {
+            return if (products.size > limit) {
+                ProductReviewsResponse(products.dropLast(REVIEW_PADDING_FOR_PAGING), hasNextPage = true)
+            } else {
+                ProductReviewsResponse(products, hasNextPage = false)
+            }
+        }
+    }
+}
+
+data class ProductReviewResponse(
+    val id: Long,
+    val productId: Long,
+    val score: Int,
+    val content: String,
+    val recommendCount: Int,
+    val hasPhotos: Boolean,
+    val createdAt: LocalDateTime,
+    val reviewerId: Long,
+    val reviewerName: String,
+    val reviewerProfileImageUrl: String?,
+    val reviewerFishBowlCount: Int,
+    val reviewerYears: Int,
+    val recommended: Boolean = false, // TODO: 추천 작업 시 추가 예정
+    val images: List<String>,
+) {
+    constructor(productReviewWithMemberResponse: ProductReviewWithMemberResponse, images: List<String>) : this(
+        id = productReviewWithMemberResponse.id,
+        productId = productReviewWithMemberResponse.productId,
+        score = productReviewWithMemberResponse.score,
+        content = productReviewWithMemberResponse.content,
+        recommendCount = productReviewWithMemberResponse.recommendCount,
+        hasPhotos = productReviewWithMemberResponse.hasPhotos,
+        createdAt = productReviewWithMemberResponse.createdAt,
+        reviewerId = productReviewWithMemberResponse.reviewerId,
+        reviewerName = productReviewWithMemberResponse.reviewerName,
+        reviewerProfileImageUrl = productReviewWithMemberResponse.reviewerProfileImageUrl,
+        reviewerFishBowlCount = productReviewWithMemberResponse.reviewerFishBowlCount,
+        reviewerYears = productReviewWithMemberResponse.reviewerYears,
+        images = images,
+    )
+}

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -13,10 +13,10 @@ data class ProductReviewReadQuery(
     val productId: Long,
     val memberId: Long?,
     val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
-    val score: Int?,
+    val score: Int? = null,
     val photoOnly: Boolean = false,
-    val lastViewedId: Long,
-    val limit: Int,
+    val lastViewedId: Long = -1,
+    val limit: Int = 20,
 ) {
 
     fun toCondition(): ProductReviewReadCondition {

--- a/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
@@ -1,8 +1,9 @@
 package com.petqua.application.product.dto
 
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.WishProduct
-import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
-import com.petqua.domain.product.dto.ProductPaging
 
 data class UpdateWishCommand(
     val memberId: Long,
@@ -18,10 +19,10 @@ data class UpdateWishCommand(
 
 data class ReadAllWishProductCommand(
     val memberId: Long,
-    val lastViewedId: Long? = null,
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
-    fun toPaging(): ProductPaging {
-        return ProductPaging.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPagingRequest {
+        return CursorBasedPagingRequest.of(lastViewedId, limit)
     }
 }

--- a/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
@@ -1,6 +1,6 @@
 package com.petqua.application.product.dto
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.WishProduct
@@ -22,7 +22,7 @@ data class ReadAllWishProductCommand(
     val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
     val limit: Int = PAGING_LIMIT_CEILING,
 ) {
-    fun toPaging(): CursorBasedPagingRequest {
-        return CursorBasedPagingRequest.of(lastViewedId, limit)
+    fun toPaging(): CursorBasedPaging {
+        return CursorBasedPaging.of(lastViewedId, limit)
     }
 }

--- a/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/WishProductDtos.kt
@@ -1,7 +1,7 @@
 package com.petqua.application.product.dto
 
 import com.petqua.domain.product.WishProduct
-import com.petqua.domain.product.dto.LIMIT_CEILING
+import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
 import com.petqua.domain.product.dto.ProductPaging
 
 data class UpdateWishCommand(
@@ -19,7 +19,7 @@ data class UpdateWishCommand(
 data class ReadAllWishProductCommand(
     val memberId: Long,
     val lastViewedId: Long? = null,
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
     fun toPaging(): ProductPaging {
         return ProductPaging.of(lastViewedId, limit)

--- a/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
+++ b/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
@@ -24,8 +24,7 @@ class ProductReviewService(
         )
         val imagesByReview = getImagesByReview(reviewsByCondition)
         val responses = reviewsByCondition.map {
-            imagesByReview[it.id]?.let { images -> ProductReviewResponse(it, images) }
-                ?: ProductReviewResponse(it, emptyList())
+            ProductReviewResponse(it, imagesByReview[it.id] ?: emptyList())
         }
         // TODO: 추천 여부 반영
         return ProductReviewsResponse.of(responses, query.limit)

--- a/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
+++ b/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
@@ -1,0 +1,39 @@
+package com.petqua.application.product.review
+
+import com.petqua.application.product.dto.ProductReviewReadQuery
+import com.petqua.application.product.dto.ProductReviewResponse
+import com.petqua.application.product.dto.ProductReviewsResponse
+import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
+import com.petqua.domain.product.review.ProductReviewImageRepository
+import com.petqua.domain.product.review.ProductReviewRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class ProductReviewService(
+    private val productReviewRepository: ProductReviewRepository,
+    private val productReviewImageRepository: ProductReviewImageRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun readAll(query: ProductReviewReadQuery): ProductReviewsResponse {
+        val reviewsByCondition = productReviewRepository.findAllByCondition(
+            query.toCondition(),
+            query.toPaging(),
+        )
+        val imagesByReview = getImagesByReview(reviewsByCondition)
+        val responses = reviewsByCondition.map {
+            imagesByReview[it.id]?.let { images -> ProductReviewResponse(it, images) }
+                ?: ProductReviewResponse(it, emptyList())
+        }
+        // TODO: 추천 여부 반영
+        return ProductReviewsResponse.of(responses, query.limit)
+    }
+
+    private fun getImagesByReview(reviewsByCondition: List<ProductReviewWithMemberResponse>): Map<Long, List<String>> {
+        val productReviewIds = reviewsByCondition.map { it.id }
+        return productReviewImageRepository.findAllByProductReviewIdIn(productReviewIds).groupBy { it.productReviewId }
+            .mapValues { it.value.map { image -> image.imageUrl } }
+    }
+}

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -10,16 +10,20 @@ import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.WishCount
+import com.petqua.domain.product.review.ProductReview
+import com.petqua.domain.product.review.ProductReviewImage
+import com.petqua.domain.product.review.ProductReviewImageRepository
+import com.petqua.domain.product.review.ProductReviewRepository
 import com.petqua.domain.recommendation.ProductRecommendation
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
+import java.math.BigDecimal
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Component
 @Profile("local", "prod")
@@ -30,6 +34,8 @@ class DataInitializer(
     private val recommendationRepository: ProductRecommendationRepository,
     private val storeRepository: StoreRepository,
     private val memberRepository: MemberRepository,
+    private val productReviewRepository: ProductReviewRepository,
+    private val productReviewImageRepository: ProductReviewImageRepository,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
@@ -122,12 +128,49 @@ class DataInitializer(
         recommendationRepository.saveAll(listOf(productRecommendation1))
 
         // member
-        val member = Member(
-            oauthId = "oauthId",
-            oauthServerNumber = 1,
-            authority = MEMBER,
+        val member = memberRepository.save(
+            Member(
+                oauthId = "oauthId",
+                oauthServerNumber = 1,
+                authority = MEMBER,
+            )
         )
-        memberRepository.save(member)
+
+// productReview
+        val reviews = productReviewRepository.saveAll(
+            listOf(
+                ProductReview(
+                    productId = product1.id,
+                    memberId = member.id,
+                    content = "좋아요",
+                    score = 5,
+                    hasPhotos = true
+                ),
+                ProductReview(
+                    productId = product1.id,
+                    memberId = member.id,
+                    content = "조금 좋아요",
+                    score = 4,
+                    hasPhotos = false
+                ),
+                ProductReview(
+                    productId = product1.id,
+                    memberId = member.id,
+                    content = "약간 좋아요",
+                    score = 3,
+                    hasPhotos = false
+                ),
+            )
+        )
+        reviews.find { it.hasPhotos }?.let {
+            productReviewImageRepository.saveAll(
+                listOf(
+                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/1.jpeg", productReviewId = it.id),
+                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/2.jpeg", productReviewId = it.id),
+                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/3.jpeg", productReviewId = it.id),
+                )
+            )
+        }
     }
 
     private fun saveProducts(storeId: Long) {

--- a/src/main/kotlin/com/petqua/common/domain/dto/CursorBasedPaging.kt
+++ b/src/main/kotlin/com/petqua/common/domain/dto/CursorBasedPaging.kt
@@ -4,16 +4,16 @@ const val DEFAULT_LAST_VIEWED_ID = -1L
 const val PAGING_LIMIT_CEILING = 20
 const val PADDING_FOR_HAS_NEXT_PAGE = 1
 
-data class CursorBasedPagingRequest internal constructor(
+data class CursorBasedPaging internal constructor(
     val lastViewedId: Long? = null,
     val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     companion object {
-        fun of(lastViewedId: Long, limit: Int): CursorBasedPagingRequest {
+        fun of(lastViewedId: Long, limit: Int): CursorBasedPaging {
             val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
             val adjustedLimit = if (limit > PAGING_LIMIT_CEILING) PAGING_LIMIT_CEILING else limit
-            return CursorBasedPagingRequest(adjustedLastViewedId, adjustedLimit + PADDING_FOR_HAS_NEXT_PAGE)
+            return CursorBasedPaging(adjustedLastViewedId, adjustedLimit + PADDING_FOR_HAS_NEXT_PAGE)
         }
     }
 }

--- a/src/main/kotlin/com/petqua/common/domain/dto/CursorBasedPagingRequest.kt
+++ b/src/main/kotlin/com/petqua/common/domain/dto/CursorBasedPagingRequest.kt
@@ -1,0 +1,19 @@
+package com.petqua.common.domain.dto
+
+const val DEFAULT_LAST_VIEWED_ID = -1L
+const val PAGING_LIMIT_CEILING = 20
+const val PADDING_FOR_HAS_NEXT_PAGE = 1
+
+data class CursorBasedPagingRequest internal constructor(
+    val lastViewedId: Long? = null,
+    val limit: Int = PAGING_LIMIT_CEILING,
+) {
+
+    companion object {
+        fun of(lastViewedId: Long, limit: Int): CursorBasedPagingRequest {
+            val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
+            val adjustedLimit = if (limit > PAGING_LIMIT_CEILING) PAGING_LIMIT_CEILING else limit
+            return CursorBasedPagingRequest(adjustedLastViewedId, adjustedLimit + PADDING_FOR_HAS_NEXT_PAGE)
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/member/Member.kt
+++ b/src/main/kotlin/com/petqua/domain/member/Member.kt
@@ -21,5 +21,16 @@ class Member(
     val oauthServerNumber: Int,
 
     @Enumerated(STRING)
-    val authority: Authority
+    val authority: Authority,
+
+    @Column(nullable = false)
+    val nickname: String = "쿠아", // FIXME: 회원 닉네임 정책 추가
+
+    val profileImageUrl: String? = null,
+
+    @Column(nullable = false)
+    val fishBowlCount: Int = 0,
+
+    @Column(nullable = false)
+    val years: Int = 1,
 )

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
@@ -1,20 +1,20 @@
 package com.petqua.domain.product
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 
 interface ProductCustomRepository {
 
-    fun findAllByCondition(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
+    fun findAllByCondition(condition: ProductReadCondition, paging: CursorBasedPaging): List<ProductResponse>
 
     fun countByCondition(condition: ProductReadCondition): Int
 
-    fun findBySearch(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
+    fun findBySearch(condition: ProductReadCondition, paging: CursorBasedPaging): List<ProductResponse>
 
     fun findAllProductResponseByIdIn(ids: List<Long>): List<ProductResponse>
 
-    fun findByKeywordSearch(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
+    fun findByKeywordSearch(condition: ProductReadCondition, paging: CursorBasedPaging): List<ProductResponse>
 
     fun countByKeywordCondition(condition: ProductReadCondition): Int
 }

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
@@ -1,20 +1,20 @@
 package com.petqua.domain.product
 
-import com.petqua.domain.product.dto.ProductPaging
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 
 interface ProductCustomRepository {
 
-    fun findAllByCondition(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse>
+    fun findAllByCondition(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
 
     fun countByCondition(condition: ProductReadCondition): Int
 
-    fun findBySearch(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse>
+    fun findBySearch(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
 
     fun findAllProductResponseByIdIn(ids: List<Long>): List<ProductResponse>
 
-    fun findByKeywordSearch(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse>
+    fun findByKeywordSearch(condition: ProductReadCondition, paging: CursorBasedPagingRequest): List<ProductResponse>
 
     fun countByKeywordCondition(condition: ProductReadCondition): Int
 }

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -4,11 +4,11 @@ import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.common.util.createCountQuery
 import com.petqua.common.util.createQuery
 import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
-import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.store.Store
@@ -24,7 +24,10 @@ class ProductCustomRepositoryImpl(
     private val jpqlRenderer: JpqlRenderer,
 ) : ProductCustomRepository {
 
-    override fun findAllByCondition(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse> {
+    override fun findAllByCondition(
+        condition: ProductReadCondition,
+        paging: CursorBasedPagingRequest
+    ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(
                 entity(Product::class),
@@ -72,7 +75,10 @@ class ProductCustomRepositoryImpl(
         )
     }
 
-    override fun findBySearch(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse> {
+    override fun findBySearch(
+        condition: ProductReadCondition,
+        paging: CursorBasedPagingRequest
+    ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(
                 entity(Product::class),
@@ -96,7 +102,10 @@ class ProductCustomRepositoryImpl(
         )
     }
 
-    override fun findByKeywordSearch(condition: ProductReadCondition, paging: ProductPaging): List<ProductResponse> {
+    override fun findByKeywordSearch(
+        condition: ProductReadCondition,
+        paging: CursorBasedPagingRequest
+    ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(
                 entity(Product::class),

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.util.createCountQuery
 import com.petqua.common.util.createQuery
 import com.petqua.domain.keyword.ProductKeyword
@@ -26,7 +26,7 @@ class ProductCustomRepositoryImpl(
 
     override fun findAllByCondition(
         condition: ProductReadCondition,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(
@@ -77,7 +77,7 @@ class ProductCustomRepositoryImpl(
 
     override fun findBySearch(
         condition: ProductReadCondition,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(
@@ -104,7 +104,7 @@ class ProductCustomRepositoryImpl(
 
     override fun findByKeywordSearch(
         condition: ProductReadCondition,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<ProductResponse> {
         val query = jpql(ProductDynamicJpqlGenerator) {
             selectNew<ProductResponse>(

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
@@ -1,9 +1,9 @@
 package com.petqua.domain.product
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.presentation.product.dto.WishProductResponse
 
 interface WishProductCustomRepository {
 
-    fun readAllWishProductResponse(memberId: Long, paging: CursorBasedPagingRequest): List<WishProductResponse>
+    fun readAllWishProductResponse(memberId: Long, paging: CursorBasedPaging): List<WishProductResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
@@ -1,7 +1,7 @@
 package com.petqua.domain.product
 
 import com.petqua.domain.product.dto.ProductPaging
-import com.petqua.presentation.product.WishProductResponse
+import com.petqua.presentation.product.dto.WishProductResponse
 
 interface WishProductCustomRepository {
 

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepository.kt
@@ -1,9 +1,9 @@
 package com.petqua.domain.product
 
-import com.petqua.domain.product.dto.ProductPaging
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.presentation.product.dto.WishProductResponse
 
 interface WishProductCustomRepository {
 
-    fun readAllWishProductResponse(memberId: Long, paging: ProductPaging): List<WishProductResponse>
+    fun readAllWishProductResponse(memberId: Long, paging: CursorBasedPagingRequest): List<WishProductResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
@@ -5,8 +5,8 @@ import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.common.util.createQuery
-import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.store.Store
 import com.petqua.presentation.product.dto.WishProductResponse
 import jakarta.persistence.EntityManager
@@ -18,7 +18,10 @@ class WishProductCustomRepositoryImpl(
     private val jpqlRenderContext: JpqlRenderContext,
     private val jpqlRenderer: JpqlRenderer,
 ) : WishProductCustomRepository {
-    override fun readAllWishProductResponse(memberId: Long, paging: ProductPaging): List<WishProductResponse> {
+    override fun readAllWishProductResponse(
+        memberId: Long,
+        paging: CursorBasedPagingRequest
+    ): List<WishProductResponse> {
         val query = jpql {
             selectNew<WishProductResponse>(
                 path(WishProduct::id),

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
@@ -8,7 +8,7 @@ import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
 import com.petqua.common.util.createQuery
 import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.store.Store
-import com.petqua.presentation.product.WishProductResponse
+import com.petqua.presentation.product.dto.WishProductResponse
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
 

--- a/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/WishProductCustomRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.util.createQuery
 import com.petqua.domain.store.Store
 import com.petqua.presentation.product.dto.WishProductResponse
@@ -20,7 +20,7 @@ class WishProductCustomRepositoryImpl(
 ) : WishProductCustomRepository {
     override fun readAllWishProductResponse(
         memberId: Long,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<WishProductResponse> {
         val query = jpql {
             selectNew<WishProductResponse>(

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -8,10 +8,6 @@ import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.INVALID_SEARCH_WORD
 import io.swagger.v3.oas.annotations.media.Schema
 
-const val PRODUCT_PADDING_FOR_PAGING = 1
-const val PRODUCT_LIMIT_CEILING = 20
-private const val DEFAULT_LAST_VIEWED_ID = -1L
-
 data class ProductReadCondition(
     val sourceType: ProductSourceType = ProductSourceType.NONE,
     val sorter: Sorter = Sorter.NONE,
@@ -31,20 +27,6 @@ data class ProductReadCondition(
         fun toSearchCondition(word: String): ProductReadCondition {
             throwExceptionWhen(word.isBlank()) { ProductException(INVALID_SEARCH_WORD) }
             return ProductReadCondition(word = word)
-        }
-    }
-}
-
-data class ProductPaging(
-    val lastViewedId: Long? = null,
-    val limit: Int = PRODUCT_LIMIT_CEILING,
-) {
-
-    companion object {
-        fun of(lastViewedId: Long?, limit: Int): ProductPaging {
-            val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
-            val adjustedLimit = if (limit > PRODUCT_LIMIT_CEILING) PRODUCT_LIMIT_CEILING else limit
-            return ProductPaging(adjustedLastViewedId, adjustedLimit + PRODUCT_PADDING_FOR_PAGING)
         }
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -8,8 +8,8 @@ import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.INVALID_SEARCH_WORD
 import io.swagger.v3.oas.annotations.media.Schema
 
-const val PADDING_FOR_PAGING = 1
-const val LIMIT_CEILING = 20
+const val PRODUCT_PADDING_FOR_PAGING = 1
+const val PRODUCT_LIMIT_CEILING = 20
 private const val DEFAULT_LAST_VIEWED_ID = -1L
 
 data class ProductReadCondition(
@@ -37,14 +37,14 @@ data class ProductReadCondition(
 
 data class ProductPaging(
     val lastViewedId: Long? = null,
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     companion object {
         fun of(lastViewedId: Long?, limit: Int): ProductPaging {
             val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
-            val adjustedLimit = if (limit > LIMIT_CEILING) LIMIT_CEILING else limit
-            return ProductPaging(adjustedLastViewedId, adjustedLimit + PADDING_FOR_PAGING)
+            val adjustedLimit = if (limit > PRODUCT_LIMIT_CEILING) PRODUCT_LIMIT_CEILING else limit
+            return ProductPaging(adjustedLastViewedId, adjustedLimit + PRODUCT_PADDING_FOR_PAGING)
         }
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -6,31 +6,12 @@ import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import java.time.LocalDateTime
 
-const val REVIEW_PADDING_FOR_PAGING = 1
-const val REVIEW_LIMIT_CEILING = 20
-private const val REVIEW_DEFAULT_LAST_VIEWED_ID = -1L
-
 data class ProductReviewReadCondition(
     val productId: Long,
     val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
     val score: Int? = null,
     val photoOnly: Boolean,
-) {
-}
-
-data class ProductReviewPaging(
-    val lastViewedId: Long? = null,
-    val limit: Int,
-) {
-
-    companion object {
-        fun of(lastViewedId: Long?, limit: Int): ProductReviewPaging {
-            val adjustedLastViewedId = if (lastViewedId == REVIEW_DEFAULT_LAST_VIEWED_ID) null else lastViewedId
-            val adjustedLimit = if (limit > REVIEW_LIMIT_CEILING) REVIEW_LIMIT_CEILING else limit
-            return ProductReviewPaging(adjustedLastViewedId, adjustedLimit + REVIEW_PADDING_FOR_PAGING)
-        }
-    }
-}
+)
 
 data class ProductReviewWithMemberResponse(
     val id: Long,

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -6,9 +6,9 @@ import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import java.time.LocalDateTime
 
-private const val REVIEW_PADDING_FOR_PAGING = 1
-private const val REVIEW_LIMIT_CEILING = 20
-private const val DEFAULT_LAST_VIEWED_ID = -1L
+const val REVIEW_PADDING_FOR_PAGING = 1
+const val REVIEW_LIMIT_CEILING = 20
+private const val REVIEW_DEFAULT_LAST_VIEWED_ID = -1L
 
 data class ProductReviewReadCondition(
     val productId: Long,
@@ -25,7 +25,7 @@ data class ProductReviewPaging(
 
     companion object {
         fun of(lastViewedId: Long?, limit: Int): ProductReviewPaging {
-            val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
+            val adjustedLastViewedId = if (lastViewedId == REVIEW_DEFAULT_LAST_VIEWED_ID) null else lastViewedId
             val adjustedLimit = if (limit > REVIEW_LIMIT_CEILING) REVIEW_LIMIT_CEILING else limit
             return ProductReviewPaging(adjustedLastViewedId, adjustedLimit + REVIEW_PADDING_FOR_PAGING)
         }

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -37,7 +37,7 @@ data class ProductReviewWithMemberResponse(
     val productId: Long,
     val score: Int,
     val content: String,
-    val createdDate: LocalDateTime,
+    val createdAt: LocalDateTime,
     val hasPhotos: Boolean,
     val recommendCount: Int,
     val reviewerId: Long,
@@ -52,11 +52,11 @@ data class ProductReviewWithMemberResponse(
         productId = productReview.productId,
         score = productReview.score,
         content = productReview.content,
-        createdDate = productReview.createdAt,
+        createdAt = productReview.createdAt,
         hasPhotos = productReview.hasPhotos,
         recommendCount = productReview.recommendCount,
         reviewerId = reviewer.id,
-        reviewerName = reviewer.nickname ?: "기본 회원", // FIXME
+        reviewerName = reviewer.nickname, // FIXME
         reviewerProfileImageUrl = reviewer.profileImageUrl,
         reviewerFishBowlCount = reviewer.fishBowlCount,
         reviewerYears = reviewer.years,

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -1,0 +1,64 @@
+package com.petqua.domain.product.dto
+
+import com.petqua.domain.member.Member
+import com.petqua.domain.product.review.ProductReview
+import com.petqua.domain.product.review.ProductReviewSorter
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import java.time.LocalDateTime
+
+private const val REVIEW_PADDING_FOR_PAGING = 1
+private const val REVIEW_LIMIT_CEILING = 20
+private const val DEFAULT_LAST_VIEWED_ID = -1L
+
+data class ProductReviewReadCondition(
+    val productId: Long,
+    val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
+    val score: Int? = null,
+    val photoOnly: Boolean,
+) {
+}
+
+data class ProductReviewPaging(
+    val lastViewedId: Long? = null,
+    val limit: Int,
+) {
+
+    companion object {
+        fun of(lastViewedId: Long?, limit: Int): ProductReviewPaging {
+            val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
+            val adjustedLimit = if (limit > REVIEW_LIMIT_CEILING) REVIEW_LIMIT_CEILING else limit
+            return ProductReviewPaging(adjustedLastViewedId, adjustedLimit + REVIEW_PADDING_FOR_PAGING)
+        }
+    }
+}
+
+data class ProductReviewWithMemberResponse(
+    val id: Long,
+    val productId: Long,
+    val score: Int,
+    val content: String,
+    val createdDate: LocalDateTime,
+    val hasPhotos: Boolean,
+    val recommendCount: Int,
+    val reviewerId: Long,
+    val reviewerName: String,
+    val reviewerProfileImageUrl: String?,
+    val reviewerFishBowlCount: Int, // FIXME: 회원 수조 개수
+    val reviewerYears: Int, // FIXME: 회원 가입 연차
+) {
+
+    constructor(productReview: ProductReview, reviewer: Member) : this(
+        id = productReview.id,
+        productId = productReview.productId,
+        score = productReview.score,
+        content = productReview.content,
+        createdDate = productReview.createdAt,
+        hasPhotos = productReview.hasPhotos,
+        recommendCount = productReview.recommendCount,
+        reviewerId = reviewer.id,
+        reviewerName = reviewer.nickname ?: "기본 회원", // FIXME
+        reviewerProfileImageUrl = reviewer.profileImageUrl,
+        reviewerFishBowlCount = reviewer.fishBowlCount,
+        reviewerYears = reviewer.years,
+    )
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
@@ -2,10 +2,12 @@ package com.petqua.domain.product.review
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
+@Entity
 class ProductReview(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -21,5 +23,11 @@ class ProductReview(
 
     @Column(nullable = false)
     val score: Int,
+
+    @Column(nullable = false)
+    val recommendCount: Int = 0,
+
+    @Column(nullable = false)
+    val hasPhotos: Boolean = false,
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
@@ -1,0 +1,25 @@
+package com.petqua.domain.product.review
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+class ProductReview(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    val content: String,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Column(nullable = false)
+    val memberId: Long,
+
+    @Column(nullable = false)
+    val score: Int,
+) : BaseEntity() {
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
@@ -1,6 +1,6 @@
 package com.petqua.domain.product.review
 
-import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 
@@ -8,6 +8,6 @@ interface ProductReviewCustomRepository {
 
     fun findAllByCondition(
         condition: ProductReviewReadCondition,
-        paging: ProductReviewPaging
+        paging: CursorBasedPagingRequest
     ): List<ProductReviewWithMemberResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
@@ -1,0 +1,4 @@
+package com.petqua.domain.product.review
+
+interface ProductReviewCustomRepository {
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
@@ -1,6 +1,6 @@
 package com.petqua.domain.product.review
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 
@@ -8,6 +8,6 @@ interface ProductReviewCustomRepository {
 
     fun findAllByCondition(
         condition: ProductReviewReadCondition,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<ProductReviewWithMemberResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
@@ -1,4 +1,13 @@
 package com.petqua.domain.product.review
 
+import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
+
 interface ProductReviewCustomRepository {
+
+    fun findAllByCondition(
+        condition: ProductReviewReadCondition,
+        paging: ProductReviewPaging
+    ): List<ProductReviewWithMemberResponse>
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.petqua.domain.product.review
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.util.createQuery
 import com.petqua.domain.member.Member
 import com.petqua.domain.product.dto.ProductReviewReadCondition
@@ -20,7 +20,7 @@ class ProductReviewCustomRepositoryImpl(
 
     override fun findAllByCondition(
         condition: ProductReviewReadCondition,
-        paging: CursorBasedPagingRequest
+        paging: CursorBasedPaging
     ): List<ProductReviewWithMemberResponse> {
 
         val query = jpql(ProductReviewDynamicJpqlGenerator) {

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -3,9 +3,9 @@ package com.petqua.domain.product.review
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.common.util.createQuery
 import com.petqua.domain.member.Member
-import com.petqua.domain.product.dto.ProductReviewPaging
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import jakarta.persistence.EntityManager
@@ -20,7 +20,7 @@ class ProductReviewCustomRepositoryImpl(
 
     override fun findAllByCondition(
         condition: ProductReviewReadCondition,
-        paging: ProductReviewPaging
+        paging: CursorBasedPagingRequest
     ): List<ProductReviewWithMemberResponse> {
 
         val query = jpql(ProductReviewDynamicJpqlGenerator) {

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -1,7 +1,16 @@
 package com.petqua.domain.product.review
 
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.sort.SortNullsStep
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.common.util.createQuery
+import com.petqua.domain.member.Member
+import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
 
@@ -11,4 +20,53 @@ class ProductReviewCustomRepositoryImpl(
     private val jpqlRenderContext: JpqlRenderContext,
     private val jpqlRenderer: JpqlRenderer,
 ) : ProductReviewCustomRepository {
+
+    override fun findAllByCondition(
+        condition: ProductReviewReadCondition,
+        paging: ProductReviewPaging
+    ): List<ProductReviewWithMemberResponse> {
+
+        val query = jpql {
+            selectDistinctNew<ProductReviewWithMemberResponse>(
+                entity(ProductReview::class),
+                entity(Member::class),
+            ).from(
+                entity(ProductReview::class),
+                join(Member::class).on(path(ProductReview::memberId).eq(path(Member::id))),
+            ).whereAnd(
+                path(ProductReview::productId).eq(condition.productId),
+                photoOnlyEq(condition.photoOnly),
+                productReviewScoreEq(condition.score),
+                productReviewIdLt(paging.lastViewedId),
+            ).orderBy(
+                sortBy(condition.sorter),
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer,
+            paging.limit
+        )
+    }
+
+    fun Jpql.productReviewIdLt(lastViewedId: Long?): Predicate? {
+        return lastViewedId?.let { path(ProductReview::id).lt(it) }
+    }
+
+    fun Jpql.photoOnlyEq(photoOnly: Boolean): Predicate? {
+        return if (photoOnly) path(ProductReview::hasPhotos).eq(true) else null
+    }
+
+    fun Jpql.productReviewScoreEq(score: Int?): Predicate? {
+        return score?.let { path(ProductReview::score).eq(it) }
+    }
+
+    fun Jpql.sortBy(sorter: ProductReviewSorter): SortNullsStep? {
+        return when (sorter) {
+            ProductReviewSorter.REVIEW_DATE_DESC -> path(ProductReview::createdAt).desc()
+            ProductReviewSorter.RECOMMEND_DESC -> path(ProductReview::recommendCount).desc()
+        }
+    }
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.petqua.domain.product.review
+
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProductReviewCustomRepositoryImpl(
+    private val entityManager: EntityManager,
+    private val jpqlRenderContext: JpqlRenderContext,
+    private val jpqlRenderer: JpqlRenderer,
+) : ProductReviewCustomRepository {
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -1,9 +1,6 @@
 package com.petqua.domain.product.review
 
-import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
-import com.linecorp.kotlinjdsl.dsl.jpql.sort.SortNullsStep
-import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
 import com.petqua.common.util.createQuery
@@ -26,7 +23,7 @@ class ProductReviewCustomRepositoryImpl(
         paging: ProductReviewPaging
     ): List<ProductReviewWithMemberResponse> {
 
-        val query = jpql {
+        val query = jpql(ProductReviewDynamicJpqlGenerator) {
             selectDistinctNew<ProductReviewWithMemberResponse>(
                 entity(ProductReview::class),
                 entity(Member::class),
@@ -49,24 +46,5 @@ class ProductReviewCustomRepositoryImpl(
             jpqlRenderer,
             paging.limit
         )
-    }
-
-    fun Jpql.productReviewIdLt(lastViewedId: Long?): Predicate? {
-        return lastViewedId?.let { path(ProductReview::id).lt(it) }
-    }
-
-    fun Jpql.photoOnlyEq(photoOnly: Boolean): Predicate? {
-        return if (photoOnly) path(ProductReview::hasPhotos).eq(true) else null
-    }
-
-    fun Jpql.productReviewScoreEq(score: Int?): Predicate? {
-        return score?.let { path(ProductReview::score).eq(it) }
-    }
-
-    fun Jpql.sortBy(sorter: ProductReviewSorter): SortNullsStep? {
-        return when (sorter) {
-            ProductReviewSorter.REVIEW_DATE_DESC -> path(ProductReview::createdAt).desc()
-            ProductReviewSorter.RECOMMEND_DESC -> path(ProductReview::recommendCount).desc()
-        }
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewDynamicJpqlGenerator.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewDynamicJpqlGenerator.kt
@@ -1,0 +1,34 @@
+package com.petqua.domain.product.review
+
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.sort.SortNullsStep
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
+import com.petqua.domain.product.review.ProductReviewSorter.RECOMMEND_DESC
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+
+class ProductReviewDynamicJpqlGenerator : Jpql() {
+
+    companion object Constructor : JpqlDsl.Constructor<ProductReviewDynamicJpqlGenerator> {
+        override fun newInstance(): ProductReviewDynamicJpqlGenerator = ProductReviewDynamicJpqlGenerator()
+    }
+
+    fun Jpql.productReviewIdLt(lastViewedId: Long?): Predicate? {
+        return lastViewedId?.let { path(ProductReview::id).lt(it) }
+    }
+
+    fun Jpql.photoOnlyEq(photoOnly: Boolean): Predicate? {
+        return if (photoOnly) path(ProductReview::hasPhotos).eq(true) else null
+    }
+
+    fun Jpql.productReviewScoreEq(score: Int?): Predicate? {
+        return score?.let { path(ProductReview::score).eq(it) }
+    }
+
+    fun Jpql.sortBy(sorter: ProductReviewSorter): SortNullsStep {
+        return when (sorter) {
+            REVIEW_DATE_DESC -> path(ProductReview::createdAt).desc()
+            RECOMMEND_DESC -> path(ProductReview::recommendCount).desc()
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImage.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImage.kt
@@ -2,11 +2,13 @@ package com.petqua.domain.product.review
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
-class ProductReviewImages(
+@Entity
+class ProductReviewImage(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImageRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImageRepository.kt
@@ -1,0 +1,8 @@
+package com.petqua.domain.product.review
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductReviewImageRepository : JpaRepository<ProductReviewImage, Long> {
+
+    fun findAllByProductReviewIdIn(productReviewId: List<Long>): List<ProductReviewImage>
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImages.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewImages.kt
@@ -1,0 +1,19 @@
+package com.petqua.domain.product.review
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+class ProductReviewImages(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    val imageUrl: String,
+
+    @Column(nullable = false)
+    val productReviewId: Long,
+) : BaseEntity() {
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewRepository.kt
@@ -1,0 +1,6 @@
+package com.petqua.domain.product.review
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductReviewRepository : JpaRepository<ProductReview, Long>, ProductReviewCustomRepository {
+}

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewSorter.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewSorter.kt
@@ -1,0 +1,8 @@
+package com.petqua.domain.product.review
+
+enum class ProductReviewSorter(
+    private val description: String,
+) {
+    REVIEW_DATE_DESC("최신순"),
+    RECOMMEND_DESC("추천순"),
+}

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -1,0 +1,30 @@
+package com.petqua.presentation.product
+
+import com.petqua.application.product.dto.ProductReviewsResponse
+import com.petqua.application.product.review.ProductReviewService
+import com.petqua.presentation.product.dto.ReadAllProductReviewsRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ProductReviewController(
+    private val productReviewService: ProductReviewService
+) {
+
+    @GetMapping("/products/{productId}/reviews")
+    fun readAll(
+//        @Auth loginMember: LoginMember, TODO: 비회원도 조회 가능 (회원인 경우 추천 여부 반영)
+        request: ReadAllProductReviewsRequest,
+        @PathVariable productId: Long,
+    ): ResponseEntity<ProductReviewsResponse> {
+        val responses = productReviewService.readAll(
+            request.toCommand(
+                productId = productId,
+                null, // loginMember.memberId
+            )
+        )
+        return ResponseEntity.ok(responses)
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -3,16 +3,22 @@ package com.petqua.presentation.product
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.application.product.review.ProductReviewService
 import com.petqua.presentation.product.dto.ReadAllProductReviewsRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "ProductReview", description = "상품 후기 관련 API 명세")
 @RestController
 class ProductReviewController(
     private val productReviewService: ProductReviewService
 ) {
 
+    @Operation(summary = "상품 후기 조건 조회 API", description = "상품의 후기를 조건에 따라 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상품 후기 조건 조회 성공")
     @GetMapping("/products/{productId}/reviews")
     fun readAll(
 //        @Auth loginMember: LoginMember, TODO: 비회원도 조회 가능 (회원인 경우 추천 여부 반영)

--- a/src/main/kotlin/com/petqua/presentation/product/WishProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/WishProductController.kt
@@ -4,6 +4,9 @@ import com.petqua.application.product.WishProductService
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
+import com.petqua.presentation.product.dto.ReadAllWishProductRequest
+import com.petqua.presentation.product.dto.UpdateWishRequest
+import com.petqua.presentation.product.dto.WishProductsResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
@@ -3,9 +3,10 @@ package com.petqua.presentation.product.dto
 import com.petqua.application.product.dto.ProductKeywordQuery
 import com.petqua.application.product.dto.ProductReadQuery
 import com.petqua.application.product.dto.ProductSearchQuery
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ProductReadRequest(
@@ -27,13 +28,13 @@ data class ProductReadRequest(
         description = "마지막으로 조회한 상품의 Id",
         example = "1"
     )
-    val lastViewedId: Long? = null,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
 
     @Schema(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductReadQuery {
@@ -57,13 +58,13 @@ data class ProductSearchRequest(
         description = "마지막으로 조회한 상품의 Id",
         example = "1"
     )
-    val lastViewedId: Long? = null,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
 
     @Schema(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductSearchQuery {
@@ -86,7 +87,7 @@ data class ProductKeywordRequest(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = PRODUCT_LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductKeywordQuery {

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
@@ -5,7 +5,7 @@ import com.petqua.application.product.dto.ProductReadQuery
 import com.petqua.application.product.dto.ProductSearchQuery
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.LIMIT_CEILING
+import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ProductReadRequest(
@@ -33,7 +33,7 @@ data class ProductReadRequest(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductReadQuery {
@@ -63,7 +63,7 @@ data class ProductSearchRequest(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductSearchQuery {
@@ -86,7 +86,7 @@ data class ProductKeywordRequest(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PRODUCT_LIMIT_CEILING,
 ) {
 
     fun toQuery(): ProductKeywordQuery {

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
@@ -1,7 +1,7 @@
 package com.petqua.presentation.product.dto
 
 import com.petqua.application.product.dto.ProductReviewReadQuery
-import com.petqua.domain.product.dto.REVIEW_LIMIT_CEILING
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import io.swagger.v3.oas.annotations.media.Schema
@@ -37,7 +37,7 @@ data class ReadAllProductReviewsRequest(
         description = "조회할 상품 개수",
         defaultValue = "20"
     )
-    val limit: Int = REVIEW_LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
     fun toCommand(productId: Long, memberId: Long?): ProductReviewReadQuery {
         return ProductReviewReadQuery(

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
@@ -1,7 +1,7 @@
 package com.petqua.presentation.product.dto
 
 import com.petqua.application.product.dto.ProductReviewReadQuery
-import com.petqua.domain.product.dto.LIMIT_CEILING
+import com.petqua.domain.product.dto.REVIEW_LIMIT_CEILING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 
@@ -10,7 +10,7 @@ data class ReadAllProductReviewsRequest(
     val lastViewedId: Long,
     val photoOnly: Boolean = false,
     val score: Int? = null,
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = REVIEW_LIMIT_CEILING,
 ) {
     fun toCommand(productId: Long, memberId: Long?): ProductReviewReadQuery {
         return ProductReviewReadQuery(

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
@@ -1,0 +1,26 @@
+package com.petqua.presentation.product.dto
+
+import com.petqua.application.product.dto.ProductReviewReadQuery
+import com.petqua.domain.product.dto.LIMIT_CEILING
+import com.petqua.domain.product.review.ProductReviewSorter
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+
+data class ReadAllProductReviewsRequest(
+    val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
+    val lastViewedId: Long,
+    val photoOnly: Boolean = false,
+    val score: Int? = null,
+    val limit: Int = LIMIT_CEILING,
+) {
+    fun toCommand(productId: Long, memberId: Long?): ProductReviewReadQuery {
+        return ProductReviewReadQuery(
+            productId = productId,
+            memberId = memberId,
+            sorter = sorter,
+            score = score,
+            photoOnly = photoOnly,
+            lastViewedId = lastViewedId,
+            limit = limit
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
@@ -4,12 +4,39 @@ import com.petqua.application.product.dto.ProductReviewReadQuery
 import com.petqua.domain.product.dto.REVIEW_LIMIT_CEILING
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ReadAllProductReviewsRequest(
+    @Schema(
+        description = "상품 후기 정렬 기준",
+        example = "REVIEW_DATE_DESC",
+        allowableValues = ["REVIEW_DATE_DESC", "RECOMMEND_DESC"]
+    )
     val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
+
+    @Schema(
+        description = "마지막으로 조회한 후기의 Id",
+        example = "1",
+    )
     val lastViewedId: Long,
+
+    @Schema(
+        description = "사진 후기만 조회 여부",
+        example = "false",
+    )
     val photoOnly: Boolean = false,
+
+    @Schema(
+        description = "조회할 후기의 평점",
+        example = "5",
+        nullable = true,
+    )
     val score: Int? = null,
+
+    @Schema(
+        description = "조회할 상품 개수",
+        defaultValue = "20"
+    )
     val limit: Int = REVIEW_LIMIT_CEILING,
 ) {
     fun toCommand(productId: Long, memberId: Long?): ProductReviewReadQuery {

--- a/src/main/kotlin/com/petqua/presentation/product/dto/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/WishProductDtos.kt
@@ -1,4 +1,4 @@
-package com.petqua.presentation.product
+package com.petqua.presentation.product.dto
 
 import com.petqua.application.product.dto.ReadAllWishProductCommand
 import com.petqua.application.product.dto.UpdateWishCommand

--- a/src/main/kotlin/com/petqua/presentation/product/dto/WishProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/WishProductDtos.kt
@@ -2,12 +2,11 @@ package com.petqua.presentation.product.dto
 
 import com.petqua.application.product.dto.ReadAllWishProductCommand
 import com.petqua.application.product.dto.UpdateWishCommand
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.Product
 import io.swagger.v3.oas.annotations.media.Schema
-
-private const val PADDING_FOR_PAGING = 1
-private const val LIMIT_CEILING = 20
-private const val DEFAULT_LAST_VIEWED_ID = -1L
 
 data class UpdateWishRequest(
     @Schema(
@@ -29,20 +28,19 @@ data class ReadAllWishProductRequest(
         description = "마지막으로 조회한 찜의 Id",
         example = "1"
     )
-    val lastViewedId: Long? = null,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
 
     @Schema(
         description = "조회할 찜 개수",
         defaultValue = "20"
     )
-    val limit: Int = LIMIT_CEILING,
+    val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
     fun toCommand(memberId: Long): ReadAllWishProductCommand {
-        val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
         return ReadAllWishProductCommand(
             memberId = memberId,
-            lastViewedId = adjustedLastViewedId,
+            lastViewedId = lastViewedId,
             limit = limit
         )
     }
@@ -67,7 +65,7 @@ data class WishProductsResponse(
         fun of(wishProducts: List<WishProductResponse>, limit: Int, totalWishProductsCount: Int): WishProductsResponse {
             return if (wishProducts.size > limit) {
                 WishProductsResponse(
-                    wishProducts.dropLast(PADDING_FOR_PAGING),
+                    wishProducts.dropLast(PADDING_FOR_HAS_NEXT_PAGE),
                     hasNextPage = true,
                     totalWishProductsCount
                 )

--- a/src/test/kotlin/com/petqua/application/product/WishProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/WishProductServiceTest.kt
@@ -13,7 +13,7 @@ import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType
-import com.petqua.presentation.product.WishProductResponse
+import com.petqua.presentation.product.dto.WishProductResponse
 import com.petqua.test.DataCleaner
 import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
@@ -22,8 +22,8 @@ import com.petqua.test.fixture.wishProduct
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
+import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class WishProductServiceTest(

--- a/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
@@ -114,7 +114,7 @@ class ProductReviewServiceTest(
             val response = productReviewService.readAll(query)
 
             Then("조건에 맞는 상품 후기 목록을 반환한다") {
-                assertSoftly(response.products) {
+                assertSoftly(response.productReviews) {
                     size shouldBe 3
                     shouldBeSortedWith(compareByDescending { it.createdAt })
                     response.hasNextPage shouldBe true
@@ -135,7 +135,7 @@ class ProductReviewServiceTest(
             val response = productReviewService.readAll(query)
 
             Then("조회된 상품 후기 목록을 반환한다") {
-                assertSoftly(response.products) {
+                assertSoftly(response.productReviews) {
                     size shouldBe 2
                     shouldBeSortedWith(compareByDescending { it.createdAt })
                     response.hasNextPage shouldBe false
@@ -156,7 +156,7 @@ class ProductReviewServiceTest(
             val response = productReviewService.readAll(query)
 
             Then("사진이 포함된 상품 후기 목록만 반환한다") {
-                assertSoftly(response.products) {
+                assertSoftly(response.productReviews) {
                     size shouldBe 3
                     shouldBeSortedWith(compareByDescending { it.createdAt })
                     response.hasNextPage shouldBe false
@@ -179,7 +179,7 @@ class ProductReviewServiceTest(
             val response = productReviewService.readAll(query)
 
             Then("해당 별점의 상품 후기 목록만 반환한다") {
-                assertSoftly(response.products) {
+                assertSoftly(response.productReviews) {
                     size shouldBe 1
                     shouldBeSortedWith(compareByDescending { it.recommendCount })
                     forAll { it.score shouldBe 3 }

--- a/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
@@ -107,8 +107,6 @@ class ProductReviewServiceTest(
                 memberId = member.id,
                 sorter = REVIEW_DATE_DESC,
                 score = null,
-                photoOnly = false,
-                lastViewedId = -1,
                 limit = 3,
             )
             val response = productReviewService.readAll(query)
@@ -126,9 +124,6 @@ class ProductReviewServiceTest(
             val query = ProductReviewReadQuery(
                 productId = product.id,
                 memberId = member.id,
-                sorter = REVIEW_DATE_DESC,
-                score = null,
-                photoOnly = false,
                 lastViewedId = savedProductReviews[2].id,  // 5개의 상품 후기 중 3번째 후기의 id
                 limit = 4,
             )
@@ -147,10 +142,7 @@ class ProductReviewServiceTest(
             val query = ProductReviewReadQuery(
                 productId = product.id,
                 memberId = member.id,
-                sorter = REVIEW_DATE_DESC,
-                score = null,
                 photoOnly = true,
-                lastViewedId = -1,
                 limit = 3,
             )
             val response = productReviewService.readAll(query)
@@ -166,19 +158,17 @@ class ProductReviewServiceTest(
             }
         }
 
-        When("별점을 입력 하면") {
+        When("별점과 정렬 조건을 입력 하면") {
             val query = ProductReviewReadQuery(
                 productId = product.id,
                 memberId = member.id,
                 sorter = RECOMMEND_DESC,
                 score = 3,
-                photoOnly = false,
-                lastViewedId = -1,
                 limit = 3,
             )
             val response = productReviewService.readAll(query)
 
-            Then("해당 별점의 상품 후기 목록만 반환한다") {
+            Then("해당 별점의 상품 후기들이 정렬 조건으로 정렬 되어 반환한다") {
                 assertSoftly(response.productReviews) {
                     size shouldBe 1
                     shouldBeSortedWith(compareByDescending { it.recommendCount })

--- a/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
@@ -1,0 +1,194 @@
+package com.petqua.application.product.review
+
+import com.petqua.application.product.dto.ProductReviewReadQuery
+import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.product.review.ProductReviewImageRepository
+import com.petqua.domain.product.review.ProductReviewRepository
+import com.petqua.domain.product.review.ProductReviewSorter.RECOMMEND_DESC
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import com.petqua.domain.store.StoreRepository
+import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.member
+import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productReview
+import com.petqua.test.fixture.productReviewImage
+import com.petqua.test.fixture.store
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldBeSortedWith
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+
+@SpringBootTest(webEnvironment = NONE)
+class ProductReviewServiceTest(
+    private val productReviewService: ProductReviewService,
+    private val memberRepository: MemberRepository,
+    private val productRepository: ProductRepository,
+    private val storeRepository: StoreRepository,
+    private val productReviewRepository: ProductReviewRepository,
+    private val productReviewImageRepository: ProductReviewImageRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    val store = storeRepository.save(store(name = "펫쿠아"))
+    val member = memberRepository.save(member(nickname = "쿠아"))
+    val product = productRepository.save(
+        product(
+            name = "상품1",
+            storeId = store.id,
+            discountPrice = BigDecimal.ZERO,
+            reviewCount = 0,
+            reviewTotalScore = 0
+        )
+    )
+
+    val savedProductReviews = productReviewRepository.saveAll(
+        listOf(
+            productReview(
+                productId = product.id,
+                reviewerId = member.id,
+                score = 5,
+                recommendCount = 1,
+                hasPhotos = false,
+            ),
+            productReview(
+                productId = product.id,
+                reviewerId = member.id,
+                score = 4,
+                recommendCount = 2,
+                hasPhotos = true,
+            ),
+            productReview(
+                productId = product.id,
+                reviewerId = member.id,
+                score = 3,
+                recommendCount = 3,
+                hasPhotos = false,
+            ),
+            productReview(
+                productId = product.id,
+                reviewerId = member.id,
+                score = 2,
+                recommendCount = 4,
+                hasPhotos = true,
+            ),
+            productReview(
+                productId = product.id,
+                reviewerId = member.id,
+                score = 1,
+                recommendCount = 5,
+                hasPhotos = true,
+            ),
+        )
+    )
+
+    val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
+    productReviewImageRepository.saveAll(
+        listOf(
+            productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
+            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
+            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
+            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
+            productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
+            productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
+        )
+    )
+
+    Given("상품 후기를 조건에 따라") {
+
+        When("전체 별점, 최신순으로 조회 하면") {
+            val query = ProductReviewReadQuery(
+                productId = product.id,
+                memberId = member.id,
+                sorter = REVIEW_DATE_DESC,
+                score = null,
+                photoOnly = false,
+                lastViewedId = -1,
+                limit = 3,
+            )
+            val response = productReviewService.readAll(query)
+
+            Then("조건에 맞는 상품 후기 목록을 반환한다") {
+                assertSoftly(response.products) {
+                    size shouldBe 3
+                    shouldBeSortedWith(compareByDescending { it.createdAt })
+                    response.hasNextPage shouldBe true
+                }
+            }
+        }
+
+        When("마지막 id의 값을 입력 하면") {
+            val query = ProductReviewReadQuery(
+                productId = product.id,
+                memberId = member.id,
+                sorter = REVIEW_DATE_DESC,
+                score = null,
+                photoOnly = false,
+                lastViewedId = savedProductReviews[2].id,  // 5개의 상품 후기 중 3번째 후기의 id
+                limit = 4,
+            )
+            val response = productReviewService.readAll(query)
+
+            Then("조회된 상품 후기 목록을 반환한다") {
+                assertSoftly(response.products) {
+                    size shouldBe 2
+                    shouldBeSortedWith(compareByDescending { it.createdAt })
+                    response.hasNextPage shouldBe false
+                }
+            }
+        }
+
+        When("사진이 있는 후기만 조회 하면") {
+            val query = ProductReviewReadQuery(
+                productId = product.id,
+                memberId = member.id,
+                sorter = REVIEW_DATE_DESC,
+                score = null,
+                photoOnly = true,
+                lastViewedId = -1,
+                limit = 3,
+            )
+            val response = productReviewService.readAll(query)
+
+            Then("사진이 포함된 상품 후기 목록만 반환한다") {
+                assertSoftly(response.products) {
+                    size shouldBe 3
+                    shouldBeSortedWith(compareByDescending { it.createdAt })
+                    response.hasNextPage shouldBe false
+                    forAll { it.hasPhotos shouldBe true }
+                    forAll { it.images.size shouldBeGreaterThanOrEqual 1 }
+                }
+            }
+        }
+
+        When("별점을 입력 하면") {
+            val query = ProductReviewReadQuery(
+                productId = product.id,
+                memberId = member.id,
+                sorter = RECOMMEND_DESC,
+                score = 3,
+                photoOnly = false,
+                lastViewedId = -1,
+                limit = 3,
+            )
+            val response = productReviewService.readAll(query)
+
+            Then("해당 별점의 상품 후기 목록만 반환한다") {
+                assertSoftly(response.products) {
+                    size shouldBe 1
+                    shouldBeSortedWith(compareByDescending { it.recommendCount })
+                    forAll { it.score shouldBe 3 }
+                }
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -1,11 +1,11 @@
 package com.petqua.domain.product
 
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.domain.product.ProductSourceType.HOME_RECOMMENDED
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.Sorter.REVIEW_COUNT_DESC
 import com.petqua.domain.product.Sorter.SALE_PRICE_ASC
 import com.petqua.domain.product.Sorter.SALE_PRICE_DESC
-import com.petqua.domain.product.dto.ProductPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.recommendation.ProductRecommendationRepository
@@ -18,10 +18,10 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal.ONE
 import java.math.BigDecimal.TEN
 import java.math.BigDecimal.ZERO
+import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class ProductCustomRepositoryImplTest(
@@ -75,7 +75,7 @@ class ProductCustomRepositoryImplTest(
         When("개수 제한을 입력하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(),
-                paging = ProductPaging(limit = 2),
+                paging = CursorBasedPagingRequest(limit = 2),
             )
 
             Then("해당 개수만큼 반환한다") {
@@ -86,7 +86,7 @@ class ProductCustomRepositoryImplTest(
         When("높은 가격 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = SALE_PRICE_DESC),
-                paging = ProductPaging(),
+                paging = CursorBasedPagingRequest(),
             )
 
             Then("높은 가격순, 최신 등록 순으로 반환된다") {
@@ -102,7 +102,7 @@ class ProductCustomRepositoryImplTest(
         When("낮은 가격순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = SALE_PRICE_ASC),
-                paging = ProductPaging(),
+                paging = CursorBasedPagingRequest(),
             )
 
             Then("낮은 가격순, 최신 등록 순으로 반환된다") {
@@ -118,7 +118,7 @@ class ProductCustomRepositoryImplTest(
         When("리뷰 많은 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = REVIEW_COUNT_DESC),
-                paging = ProductPaging(),
+                paging = CursorBasedPagingRequest(),
             )
 
             Then("리뷰 많은 순, 최신 등록 순으로 반환된다") {
@@ -134,7 +134,7 @@ class ProductCustomRepositoryImplTest(
         When("최신 등록 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = ENROLLMENT_DATE_DESC),
-                paging = ProductPaging(),
+                paging = CursorBasedPagingRequest(),
             )
 
             Then("최신 등록 순으로 반환된다") {
@@ -150,7 +150,7 @@ class ProductCustomRepositoryImplTest(
         When("추천 상품을 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sourceType = HOME_RECOMMENDED, sorter = ENROLLMENT_DATE_DESC),
-                paging = ProductPaging(),
+                paging = CursorBasedPagingRequest(),
             )
 
             Then("추천 상품이 최신 등록 순으로 반환된다") {
@@ -234,7 +234,7 @@ class ProductCustomRepositoryImplTest(
         When("상품 이름을 정확히 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "상품1"),
-                paging = ProductPaging()
+                paging = CursorBasedPagingRequest()
             )
 
             Then("해당 이름의 상품을 반환한다") {
@@ -247,7 +247,7 @@ class ProductCustomRepositoryImplTest(
         When("상품 이름을 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "상품"),
-                paging = ProductPaging()
+                paging = CursorBasedPagingRequest()
             )
 
             Then("관련된 이름의 상품들을 반환한다") {
@@ -263,7 +263,7 @@ class ProductCustomRepositoryImplTest(
         When("존재하지 않는 상품 이름을 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "NON EXISTENT PRODUCT"),
-                paging = ProductPaging()
+                paging = CursorBasedPagingRequest()
             )
 
             Then("상품을 반환하지 않는다") {

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -1,6 +1,6 @@
 package com.petqua.domain.product
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.product.ProductSourceType.HOME_RECOMMENDED
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.Sorter.REVIEW_COUNT_DESC
@@ -75,7 +75,7 @@ class ProductCustomRepositoryImplTest(
         When("개수 제한을 입력하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(),
-                paging = CursorBasedPagingRequest(limit = 2),
+                paging = CursorBasedPaging(limit = 2),
             )
 
             Then("해당 개수만큼 반환한다") {
@@ -86,7 +86,7 @@ class ProductCustomRepositoryImplTest(
         When("높은 가격 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = SALE_PRICE_DESC),
-                paging = CursorBasedPagingRequest(),
+                paging = CursorBasedPaging(),
             )
 
             Then("높은 가격순, 최신 등록 순으로 반환된다") {
@@ -102,7 +102,7 @@ class ProductCustomRepositoryImplTest(
         When("낮은 가격순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = SALE_PRICE_ASC),
-                paging = CursorBasedPagingRequest(),
+                paging = CursorBasedPaging(),
             )
 
             Then("낮은 가격순, 최신 등록 순으로 반환된다") {
@@ -118,7 +118,7 @@ class ProductCustomRepositoryImplTest(
         When("리뷰 많은 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = REVIEW_COUNT_DESC),
-                paging = CursorBasedPagingRequest(),
+                paging = CursorBasedPaging(),
             )
 
             Then("리뷰 많은 순, 최신 등록 순으로 반환된다") {
@@ -134,7 +134,7 @@ class ProductCustomRepositoryImplTest(
         When("최신 등록 순으로 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sorter = ENROLLMENT_DATE_DESC),
-                paging = CursorBasedPagingRequest(),
+                paging = CursorBasedPaging(),
             )
 
             Then("최신 등록 순으로 반환된다") {
@@ -150,7 +150,7 @@ class ProductCustomRepositoryImplTest(
         When("추천 상품을 조회하면") {
             val products = productRepository.findAllByCondition(
                 condition = ProductReadCondition(sourceType = HOME_RECOMMENDED, sorter = ENROLLMENT_DATE_DESC),
-                paging = CursorBasedPagingRequest(),
+                paging = CursorBasedPaging(),
             )
 
             Then("추천 상품이 최신 등록 순으로 반환된다") {
@@ -234,7 +234,7 @@ class ProductCustomRepositoryImplTest(
         When("상품 이름을 정확히 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "상품1"),
-                paging = CursorBasedPagingRequest()
+                paging = CursorBasedPaging()
             )
 
             Then("해당 이름의 상품을 반환한다") {
@@ -247,7 +247,7 @@ class ProductCustomRepositoryImplTest(
         When("상품 이름을 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "상품"),
-                paging = CursorBasedPagingRequest()
+                paging = CursorBasedPaging()
             )
 
             Then("관련된 이름의 상품들을 반환한다") {
@@ -263,7 +263,7 @@ class ProductCustomRepositoryImplTest(
         When("존재하지 않는 상품 이름을 입력하면") {
             val products = productRepository.findBySearch(
                 condition = ProductReadCondition(word = "NON EXISTENT PRODUCT"),
-                paging = CursorBasedPagingRequest()
+                paging = CursorBasedPaging()
             )
 
             Then("상품을 반환하지 않는다") {

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -1,0 +1,168 @@
+package com.petqua.domain.product.review
+
+import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.product.dto.ProductReviewPaging
+import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.review.ProductReviewSorter.RECOMMEND_DESC
+import com.petqua.domain.store.StoreRepository
+import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.member
+import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productReview
+import com.petqua.test.fixture.store
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldBeSortedWith
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ProductReviewCustomRepositoryImplTest(
+    private val memberRepository: MemberRepository,
+    private val productRepository: ProductRepository,
+    private val storeRepository: StoreRepository,
+    private val productReviewRepository: ProductReviewRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    Given("조건에 따라 상품 후기를 조회 할 때") {
+        val store = storeRepository.save(store(name = "펫쿠아"))
+        val member = memberRepository.save(member(nickname = "쿠아"))
+        val product = productRepository.save(
+            product(
+                name = "상품1",
+                storeId = store.id,
+                discountPrice = BigDecimal.ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
+            )
+        )
+
+        productReviewRepository.saveAll(
+            listOf(
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 1,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 4,
+                    recommendCount = 2,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 3,
+                    recommendCount = 3,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 4,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 1,
+                    recommendCount = 5,
+                    hasPhotos = true,
+                ),
+            )
+        )
+
+        When("조건 없이 기본 값으로 전체 조회 하면") {
+            val productReviewResponse = productReviewRepository.findAllByCondition(
+                condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
+                paging = ProductReviewPaging(limit = 3),
+            )
+
+            Then("조회된 상품 후기 목록을 반환한다") {
+                assertSoftly(productReviewResponse) {
+                    size shouldBe 3
+                    shouldBeSortedWith(compareByDescending { it.createdDate })
+                }
+            }
+        }
+
+        When("마지막 id의 값을 입력 하면") {
+            val productReviewResponse = productReviewRepository.findAllByCondition(
+                condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
+                paging = ProductReviewPaging(lastViewedId = 3L, limit = 3), // id가 5,4,3,2,1 인 리뷰중 [2, 1] 만 조회 된다.
+            )
+
+            Then("해당 id 이후의 상품 후기 목록을 반환한다") {
+                assertSoftly(productReviewResponse) {
+                    size shouldBe 2
+                    shouldBeSortedWith(compareByDescending { it.createdDate })
+                }
+            }
+        }
+
+        When("정렬 기준을 입력 하면") {
+            val productReviewResponse = productReviewRepository.findAllByCondition(
+                condition = ProductReviewReadCondition(
+                    productId = product.id,
+                    photoOnly = false,
+                    sorter = RECOMMEND_DESC
+                ),
+                paging = ProductReviewPaging(limit = 3),
+            )
+
+            Then("해당 기준으로 정렬된 상품 후기를 반환 한다") {
+                assertSoftly(productReviewResponse) {
+                    size shouldBe 3
+                    shouldBeSortedWith(compareByDescending { it.recommendCount })
+                }
+            }
+        }
+
+        When("사진 리뷰 필터를 추가 하면") {
+            val productReviewResponse = productReviewRepository.findAllByCondition(
+                condition = ProductReviewReadCondition(
+                    productId = product.id,
+                    photoOnly = true,
+                    sorter = RECOMMEND_DESC
+                ),
+                paging = ProductReviewPaging(limit = 3),
+            )
+
+            Then("사진 리뷰만 조회 된다") {
+                productReviewResponse.forAll { it.hasPhotos shouldBe true }
+            }
+        }
+
+        When("사진 리뷰 필터와 점수 필터를 추가 하면") {
+            val productReviewResponse = productReviewRepository.findAllByCondition(
+                condition = ProductReviewReadCondition(
+                    productId = product.id,
+                    photoOnly = true,
+                    sorter = RECOMMEND_DESC,
+                    score = 3,
+                ),
+                paging = ProductReviewPaging(limit = 3),
+            )
+
+            Then("사진 리뷰만 조회 된다") {
+                productReviewResponse.forAll {
+                    it.hasPhotos shouldBe true
+                    it.score shouldBe 3
+                }
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -153,7 +153,7 @@ class ProductReviewCustomRepositoryImplTest(
                 paging = ProductReviewPaging(limit = 3),
             )
 
-            Then("사진 리뷰만 조회 된다") {
+            Then("점수 필터가 적용된 사진 리뷰가 조회된다") {
                 productReviewResponse.forAll {
                     it.hasPhotos shouldBe true
                     it.score shouldBe 3

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -1,8 +1,8 @@
 package com.petqua.domain.product.review
 
+import com.petqua.common.domain.dto.CursorBasedPagingRequest
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
-import com.petqua.domain.product.dto.ProductReviewPaging
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.review.ProductReviewSorter.RECOMMEND_DESC
 import com.petqua.domain.store.StoreRepository
@@ -84,7 +84,7 @@ class ProductReviewCustomRepositoryImplTest(
         When("조건 없이 기본 값으로 전체 조회 하면") {
             val productReviewResponse = productReviewRepository.findAllByCondition(
                 condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
-                paging = ProductReviewPaging(limit = 3),
+                paging = CursorBasedPagingRequest(limit = 3),
             )
 
             Then("조회된 상품 후기 목록을 반환한다") {
@@ -98,7 +98,7 @@ class ProductReviewCustomRepositoryImplTest(
         When("마지막 id의 값을 입력 하면") {
             val productReviewResponse = productReviewRepository.findAllByCondition(
                 condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
-                paging = ProductReviewPaging(lastViewedId = 3L, limit = 3), // id가 5,4,3,2,1 인 리뷰중 [2, 1] 만 조회 된다.
+                paging = CursorBasedPagingRequest(lastViewedId = 3L, limit = 3), // id가 5,4,3,2,1 인 리뷰중 [2, 1] 만 조회 된다.
             )
 
             Then("해당 id 이후의 상품 후기 목록을 반환한다") {
@@ -116,7 +116,7 @@ class ProductReviewCustomRepositoryImplTest(
                     photoOnly = false,
                     sorter = RECOMMEND_DESC
                 ),
-                paging = ProductReviewPaging(limit = 3),
+                paging = CursorBasedPagingRequest(limit = 3),
             )
 
             Then("해당 기준으로 정렬된 상품 후기를 반환 한다") {
@@ -134,7 +134,7 @@ class ProductReviewCustomRepositoryImplTest(
                     photoOnly = true,
                     sorter = RECOMMEND_DESC
                 ),
-                paging = ProductReviewPaging(limit = 3),
+                paging = CursorBasedPagingRequest(limit = 3),
             )
 
             Then("사진 리뷰만 조회 된다") {
@@ -150,7 +150,7 @@ class ProductReviewCustomRepositoryImplTest(
                     sorter = RECOMMEND_DESC,
                     score = 3,
                 ),
-                paging = ProductReviewPaging(limit = 3),
+                paging = CursorBasedPagingRequest(limit = 3),
             )
 
             Then("점수 필터가 적용된 사진 리뷰가 조회된다") {

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -1,6 +1,6 @@
 package com.petqua.domain.product.review
 
-import com.petqua.common.domain.dto.CursorBasedPagingRequest
+import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.dto.ProductReviewReadCondition
@@ -84,7 +84,7 @@ class ProductReviewCustomRepositoryImplTest(
         When("조건 없이 기본 값으로 전체 조회 하면") {
             val productReviewResponse = productReviewRepository.findAllByCondition(
                 condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
-                paging = CursorBasedPagingRequest(limit = 3),
+                paging = CursorBasedPaging(limit = 3),
             )
 
             Then("조회된 상품 후기 목록을 반환한다") {
@@ -98,7 +98,7 @@ class ProductReviewCustomRepositoryImplTest(
         When("마지막 id의 값을 입력 하면") {
             val productReviewResponse = productReviewRepository.findAllByCondition(
                 condition = ProductReviewReadCondition(productId = product.id, photoOnly = false),
-                paging = CursorBasedPagingRequest(lastViewedId = 3L, limit = 3), // id가 5,4,3,2,1 인 리뷰중 [2, 1] 만 조회 된다.
+                paging = CursorBasedPaging(lastViewedId = 3L, limit = 3), // id가 5,4,3,2,1 인 리뷰중 [2, 1] 만 조회 된다.
             )
 
             Then("해당 id 이후의 상품 후기 목록을 반환한다") {
@@ -116,7 +116,7 @@ class ProductReviewCustomRepositoryImplTest(
                     photoOnly = false,
                     sorter = RECOMMEND_DESC
                 ),
-                paging = CursorBasedPagingRequest(limit = 3),
+                paging = CursorBasedPaging(limit = 3),
             )
 
             Then("해당 기준으로 정렬된 상품 후기를 반환 한다") {
@@ -134,7 +134,7 @@ class ProductReviewCustomRepositoryImplTest(
                     photoOnly = true,
                     sorter = RECOMMEND_DESC
                 ),
-                paging = CursorBasedPagingRequest(limit = 3),
+                paging = CursorBasedPaging(limit = 3),
             )
 
             Then("사진 리뷰만 조회 된다") {
@@ -150,7 +150,7 @@ class ProductReviewCustomRepositoryImplTest(
                     sorter = RECOMMEND_DESC,
                     score = 3,
                 ),
-                paging = CursorBasedPagingRequest(limit = 3),
+                paging = CursorBasedPaging(limit = 3),
             )
 
             Then("점수 필터가 적용된 사진 리뷰가 조회된다") {

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -90,7 +90,7 @@ class ProductReviewCustomRepositoryImplTest(
             Then("조회된 상품 후기 목록을 반환한다") {
                 assertSoftly(productReviewResponse) {
                     size shouldBe 3
-                    shouldBeSortedWith(compareByDescending { it.createdDate })
+                    shouldBeSortedWith(compareByDescending { it.createdAt })
                 }
             }
         }
@@ -104,7 +104,7 @@ class ProductReviewCustomRepositoryImplTest(
             Then("해당 id 이후의 상품 후기 목록을 반환한다") {
                 assertSoftly(productReviewResponse) {
                     size shouldBe 2
-                    shouldBeSortedWith(compareByDescending { it.createdDate })
+                    shouldBeSortedWith(compareByDescending { it.createdAt })
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -52,8 +52,9 @@ fun requestUpdateCartProductOption(
             .body(request)
             .auth().preemptive().oauth2(accessToken)
             .contentType("application/json")
+            .pathParam("cartProductId", cartProductId)
     } When {
-        patch("/carts/{cartProductId}/options", cartProductId)
+        patch("/carts/{cartProductId}/options")
     } Then {
         log().all()
     } Extract {
@@ -69,8 +70,9 @@ fun requestDeleteCartProduct(
         log().all()
             .auth().preemptive().oauth2(accessToken)
             .contentType("application/json")
+            .pathParam("cartProductId", deleteProductId)
     } When {
-        delete("/carts/{cartProductId}", deleteProductId)
+        delete("/carts/{cartProductId}")
     } Then {
         log().all()
     } Extract {

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
@@ -2,7 +2,7 @@ package com.petqua.presentation.product
 
 import com.petqua.domain.product.ProductSourceType.NONE
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.LIMIT_CEILING
+import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -29,7 +29,7 @@ fun requestReadAllProducts(
     sourceType: String = NONE.name,
     sorter: String = Sorter.NONE.name,
     lastViewedId: Long? = null,
-    limit: Int = LIMIT_CEILING,
+    limit: Int = PRODUCT_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {
@@ -51,7 +51,7 @@ fun requestReadAllProducts(
 
 fun requestReadProductKeyword(
     word: String = "",
-    limit: Int = LIMIT_CEILING,
+    limit: Int = PRODUCT_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {
@@ -72,7 +72,7 @@ fun requestReadProductKeyword(
 fun requestReadProductBySearch(
     word: String = "",
     lastViewedId: Long? = null,
-    limit: Int = LIMIT_CEILING,
+    limit: Int = PRODUCT_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
@@ -1,8 +1,9 @@
 package com.petqua.presentation.product
 
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.product.ProductSourceType.NONE
 import com.petqua.domain.product.Sorter
-import com.petqua.domain.product.dto.PRODUCT_LIMIT_CEILING
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -28,8 +29,8 @@ fun requestReadProductById(
 fun requestReadAllProducts(
     sourceType: String = NONE.name,
     sorter: String = Sorter.NONE.name,
-    lastViewedId: Long? = null,
-    limit: Int = PRODUCT_LIMIT_CEILING,
+    lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    limit: Int = PAGING_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {
@@ -51,7 +52,7 @@ fun requestReadAllProducts(
 
 fun requestReadProductKeyword(
     word: String = "",
-    limit: Int = PRODUCT_LIMIT_CEILING,
+    limit: Int = PAGING_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {
@@ -71,8 +72,8 @@ fun requestReadProductKeyword(
 
 fun requestReadProductBySearch(
     word: String = "",
-    lastViewedId: Long? = null,
-    limit: Int = PRODUCT_LIMIT_CEILING,
+    lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    limit: Int = PAGING_LIMIT_CEILING,
     accessToken: String
 ): Response {
     return Given {

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
@@ -24,8 +24,9 @@ fun requestReadAllReviewProducts(
             "score", score,
             "photoOnly", photoOnly
         )
+        pathParam("productId", productId)
     } When {
-        get("/products/{productId}/reviews", productId)
+        get("/products/{productId}/reviews")
     } Then {
         log().all()
     } Extract {

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
@@ -1,0 +1,34 @@
+import com.petqua.domain.product.review.ProductReviewSorter
+import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.restassured.response.Response
+
+
+fun requestReadAllReviewProducts(
+    productId: Long,
+    sorter: ProductReviewSorter = REVIEW_DATE_DESC,
+    lastViewedId: Long = -1,
+    limit: Int = 20,
+    score: Int? = null,
+    photoOnly: Boolean = false
+): Response {
+    return Given {
+        log().all()
+        params(
+            "sorter", sorter.name,
+            "lastViewedId", lastViewedId,
+            "limit", limit,
+            "score", score,
+            "photoOnly", photoOnly
+        )
+    } When {
+        get("/products/{productId}/reviews", productId)
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
@@ -102,7 +102,7 @@ class ProductReviewControllerTest(
                 Then("조회된 상품 후기 목록을 반환한다") {
                     val responseBody = response.`as`(ProductReviewsResponse::class.java)
 
-                    assertSoftly(responseBody.products) {
+                    assertSoftly(responseBody.productReviews) {
                         size shouldBe 3
                         shouldBeSortedWith(compareByDescending { it.createdAt })
                     }
@@ -116,8 +116,8 @@ class ProductReviewControllerTest(
                     val responseBody = response.`as`(ProductReviewsResponse::class.java)
 
                     assertSoftly(responseBody) {
-                        products.size shouldBe 2
-                        products shouldBeSortedWith compareByDescending { it.createdAt }
+                        productReviews.size shouldBe 2
+                        productReviews shouldBeSortedWith compareByDescending { it.createdAt }
                         hasNextPage shouldBe false
                     }
                 }
@@ -129,7 +129,7 @@ class ProductReviewControllerTest(
                 Then("사진이 있는 상품 후기 목록을 반환한다") {
                     val responseBody = response.`as`(ProductReviewsResponse::class.java)
 
-                    assertSoftly(responseBody.products) {
+                    assertSoftly(responseBody.productReviews) {
                         size shouldBe 3
                         shouldBeSortedWith(compareByDescending { it.createdAt })
                         forAll { it.hasPhotos shouldBe true }
@@ -144,7 +144,7 @@ class ProductReviewControllerTest(
                 Then("해당 별점의 상품 후기 목록만 반환한다") {
                     val responseBody = response.`as`(ProductReviewsResponse::class.java)
 
-                    assertSoftly(responseBody.products) {
+                    assertSoftly(responseBody.productReviews) {
                         size shouldBe 1
                         forAll { it.score shouldBe 3 }
                     }

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
@@ -1,0 +1,155 @@
+package com.petqua.presentation.product
+
+import com.petqua.application.product.dto.ProductReviewsResponse
+import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.product.review.ProductReviewImageRepository
+import com.petqua.domain.product.review.ProductReviewRepository
+import com.petqua.domain.store.StoreRepository
+import com.petqua.test.ApiTestConfig
+import com.petqua.test.fixture.member
+import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productReview
+import com.petqua.test.fixture.productReviewImage
+import com.petqua.test.fixture.store
+import io.kotest.assertions.assertSoftly
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldBeSortedWith
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import requestReadAllReviewProducts
+
+class ProductReviewControllerTest(
+    private val memberRepository: MemberRepository,
+    private val productRepository: ProductRepository,
+    private val storeRepository: StoreRepository,
+    private val productReviewRepository: ProductReviewRepository,
+    private val productReviewImageRepository: ProductReviewImageRepository,
+) : ApiTestConfig() {
+    init {
+
+        val store = storeRepository.save(store(name = "펫쿠아"))
+        val member = memberRepository.save(member(nickname = "쿠아"))
+        val product = productRepository.save(
+            product(
+                name = "상품1",
+                storeId = store.id,
+                discountPrice = BigDecimal.ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
+            )
+        )
+
+        val savedProductReviews = productReviewRepository.saveAll(
+            listOf(
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 1,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 4,
+                    recommendCount = 2,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 3,
+                    recommendCount = 3,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 4,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 1,
+                    recommendCount = 5,
+                    hasPhotos = true,
+                ),
+            )
+        )
+
+        val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
+        productReviewImageRepository.saveAll(
+            listOf(
+                productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
+            )
+        )
+
+        Given("조건에 따라 상품 후기를 조회 하면") {
+
+            When("전체 별점, 최신순으로 조회 하면") {
+
+                val response = requestReadAllReviewProducts(productId = product.id, limit = 3)
+
+                Then("조회된 상품 후기 목록을 반환한다") {
+                    val responseBody = response.`as`(ProductReviewsResponse::class.java)
+
+                    assertSoftly(responseBody.products) {
+                        size shouldBe 3
+                        shouldBeSortedWith(compareByDescending { it.createdAt })
+                    }
+                }
+            }
+
+            When("마지막 id의 값을 입력 하면") {
+                val response = requestReadAllReviewProducts(productId = product.id, lastViewedId = 3)
+
+                Then("그 이후의 상품 후기 목록을 반환한다") {
+                    val responseBody = response.`as`(ProductReviewsResponse::class.java)
+
+                    assertSoftly(responseBody) {
+                        products.size shouldBe 2
+                        products shouldBeSortedWith compareByDescending { it.createdAt }
+                        hasNextPage shouldBe false
+                    }
+                }
+            }
+
+            When("사진만 조회 하면") {
+                val response = requestReadAllReviewProducts(productId = product.id, photoOnly = true)
+
+                Then("사진이 있는 상품 후기 목록을 반환한다") {
+                    val responseBody = response.`as`(ProductReviewsResponse::class.java)
+
+                    assertSoftly(responseBody.products) {
+                        size shouldBe 3
+                        shouldBeSortedWith(compareByDescending { it.createdAt })
+                        forAll { it.hasPhotos shouldBe true }
+                        forAll { it.images.size shouldBeGreaterThanOrEqual 1 }
+                    }
+                }
+            }
+
+            When("별점 3점만 조회 하면") {
+                val response = requestReadAllReviewProducts(productId = product.id, score = 3)
+
+                Then("해당 별점의 상품 후기 목록만 반환한다") {
+                    val responseBody = response.`as`(ProductReviewsResponse::class.java)
+
+                    assertSoftly(responseBody.products) {
+                        size shouldBe 1
+                        forAll { it.score shouldBe 3 }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/product/WishProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/WishProductControllerTest.kt
@@ -6,6 +6,8 @@ import com.petqua.domain.product.WishProduct
 import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
+import com.petqua.presentation.product.dto.UpdateWishRequest
+import com.petqua.presentation.product.dto.WishProductsResponse
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.product
 import com.petqua.test.fixture.store
@@ -14,10 +16,10 @@ import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import java.math.BigDecimal
 import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType
-import java.math.BigDecimal
 
 class WishProductControllerTest(
     wishProductRepository: WishProductRepository,

--- a/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/MemberFixtures.kt
@@ -7,12 +7,20 @@ fun member(
     id: Long = 0L,
     oauthId: String = "oauthId",
     oauthServerNumber: Int = 1,
-    authority: Authority = Authority.MEMBER
+    authority: Authority = Authority.MEMBER,
+    nickname: String = "nickname",
+    profileImageUrl: String = "profile.jpg",
+    fishBowlCount: Int = 0,
+    years: Int = 1,
 ): Member {
     return Member(
         id,
         oauthId,
         oauthServerNumber,
-        authority
+        authority,
+        nickname,
+        profileImageUrl,
+        fishBowlCount,
+        years,
     )
 }

--- a/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
@@ -1,0 +1,23 @@
+package com.petqua.test.fixture
+
+import com.petqua.domain.product.review.ProductReview
+
+fun productReview(
+    id: Long = 0L,
+    content: String = "content",
+    productId: Long,
+    reviewerId: Long,
+    score: Int = 5,
+    recommendCount: Int = 0,
+    hasPhotos: Boolean = false,
+): ProductReview {
+    return ProductReview(
+        id = id,
+        content = content,
+        productId = productId,
+        memberId = reviewerId,
+        score = score,
+        recommendCount = recommendCount,
+        hasPhotos = hasPhotos,
+    )
+}

--- a/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
@@ -1,6 +1,7 @@
 package com.petqua.test.fixture
 
 import com.petqua.domain.product.review.ProductReview
+import com.petqua.domain.product.review.ProductReviewImage
 
 fun productReview(
     id: Long = 0L,
@@ -19,5 +20,17 @@ fun productReview(
         score = score,
         recommendCount = recommendCount,
         hasPhotos = hasPhotos,
+    )
+}
+
+fun productReviewImage(
+    id: Long = 0L,
+    imageUrl: String = "imageUrl",
+    productReviewId: Long,
+): ProductReviewImage {
+    return ProductReviewImage(
+        id = id,
+        imageUrl = imageUrl,
+        productReviewId = productReviewId,
     )
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #51 

### 📁 작업 설명
상품 후기 조회 API 구현
- 조건에 따른 무한 스크롤 api를 구현하였습니다.
사진 리뷰, 별점 필터와 최신순, 추천순 정렬 조건이 존재합니다.
- 회원의 추천여부가 응답에 포함되어야 하는데, 아직 추천 부분 개발이 진행 되지 않아 TODO로 남겨두었습니다.


### 📸 작업화면
API 응답 sample
```json
{
    "productReviews": [
        {
            "id": 10,
            "productId": 2,
            "score": 1,
            "content": "content",
            "recommendCount": 5,
            "hasPhotos": true,
            "createdAt": "2024-02-08T13:47:49.590339",
            "reviewerId": 2,
            "reviewerName": "쿠아",
            "reviewerProfileImageUrl": "profile.jpg",
            "reviewerFishBowlCount": 0,
            "reviewerYears": 1,
            "recommended": false, // TODO 추천 여부
            "images": [
                "imageUrl3-1",
                "imageUrl3-2"
            ]
        },
        {
            "id": 9,
            "productId": 2,
            "score": 2,
            "content": "content",
            "recommendCount": 4,
            "hasPhotos": true,
            "createdAt": "2024-02-08T13:47:49.58926",
            "reviewerId": 2,
            "reviewerName": "쿠아",
            "reviewerProfileImageUrl": "profile.jpg",
            "reviewerFishBowlCount": 0,
            "reviewerYears": 1,
            "recommended": false,
            "images": [
                "imageUrl2-1",
                "imageUrl2-2",
                "imageUrl2-3"
            ]
        },
        {
            "id": 8,
            "productId": 2,
            "score": 3,
            "content": "content",
            "recommendCount": 3,
            "hasPhotos": false,
            "createdAt": "2024-02-08T13:47:49.587809",
            "reviewerId": 2,
            "reviewerName": "쿠아",
            "reviewerProfileImageUrl": "profile.jpg",
            "reviewerFishBowlCount": 0,
            "reviewerYears": 1,
            "recommended": false,
            "images": [
                
            ]
        }
    ],
    "hasNextPage": true
}

```
### 💻 미완료 태스크(선택)
<!-- 내용이 포함되지 않으면 제거 -->
- [ ] 회원/비회원에 따른 추천 여부 정보 포함하여 응답

### 기타
-  회원 데이터에 [닉네임], [수조 개수], [가입 연차] 정보가 추가되었습니다. 후기 조회에 보여지는 정보들인데, 마이페이지가 추가되면 해당되는 값들에 대한 상세한 정책이 나온다고 하셨습니다.
우선 필드만 추가해두었어요!