### PR TITLE
feature: 상품 후기 통계 조회 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -8,6 +8,7 @@ import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
+import com.petqua.domain.product.review.ProductReviewStatistics
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -157,7 +158,7 @@ data class ProductReviewResponse(
     )
 }
 
-data class ProductReviewScoreStatistics(
+data class ProductReviewStatisticsResponse(
     @Schema(
         description = "별점 5의 개수",
         example = "3"
@@ -187,16 +188,37 @@ data class ProductReviewScoreStatistics(
         example = "0"
     )
     val scoreOneCount: Int,
+
+    @Schema(
+        description = "만족도",
+        example = "98"
+    )
+    val productSatisfaction: Int,
+
+    @Schema(
+        description = "후기 총 개수",
+        example = "15"
+    )
+    val totalReviewCount: Int,
+
+    @Schema(
+        description = "평균 별점",
+        example = "4.3"
+    )
+    val averageScore: Double,
 ) {
 
     companion object {
-        fun from(countsByScores: Map<Int, Long>): ProductReviewScoreStatistics {
-            return ProductReviewScoreStatistics(
-                scoreFiveCount = countsByScores[5]?.toInt() ?: 0,
-                scoreFourCount = countsByScores[4]?.toInt() ?: 0,
-                scoreThreeCount = countsByScores[3]?.toInt() ?: 0,
-                scoreTwoCount = countsByScores[2]?.toInt() ?: 0,
-                scoreOneCount = countsByScores[1]?.toInt() ?: 0,
+        fun from(countsByScores: ProductReviewStatistics): ProductReviewStatisticsResponse {
+            return ProductReviewStatisticsResponse(
+                scoreFiveCount = countsByScores.scoreFiveCount,
+                scoreFourCount = countsByScores.scoreFourCount,
+                scoreThreeCount = countsByScores.scoreThreeCount,
+                scoreTwoCount = countsByScores.scoreTwoCount,
+                scoreOneCount = countsByScores.scoreOneCount,
+                productSatisfaction = countsByScores.productSatisfaction,
+                totalReviewCount = countsByScores.totalReviewCount,
+                averageScore = countsByScores.averageScore,
             )
         }
     }

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -158,13 +158,37 @@ data class ProductReviewResponse(
 }
 
 data class ProductReviewScoreStatistics(
+    @Schema(
+        description = "별점 5의 개수",
+        example = "3"
+    )
     val scoreFiveCount: Int,
+
+    @Schema(
+        description = "별점 4의 개수",
+        example = "0"
+    )
     val scoreFourCount: Int,
+
+    @Schema(
+        description = "별점 3의 개수",
+        example = "0"
+    )
     val scoreThreeCount: Int,
+
+    @Schema(
+        description = "별점 2의 개수",
+        example = "2"
+    )
     val scoreTwoCount: Int,
+
+    @Schema(
+        description = "별점 1의 개수",
+        example = "0"
+    )
     val scoreOneCount: Int,
 ) {
-    
+
     companion object {
         fun from(countsByScores: Map<Int, Long>): ProductReviewScoreStatistics {
             return ProductReviewScoreStatistics(

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -156,3 +156,24 @@ data class ProductReviewResponse(
         images = images,
     )
 }
+
+data class ProductReviewScoreStatistics(
+    val scoreFiveCount: Int,
+    val scoreFourCount: Int,
+    val scoreThreeCount: Int,
+    val scoreTwoCount: Int,
+    val scoreOneCount: Int,
+) {
+    
+    companion object {
+        fun from(countsByScores: Map<Int, Long>): ProductReviewScoreStatistics {
+            return ProductReviewScoreStatistics(
+                scoreFiveCount = countsByScores[5]?.toInt() ?: 0,
+                scoreFourCount = countsByScores[4]?.toInt() ?: 0,
+                scoreThreeCount = countsByScores[3]?.toInt() ?: 0,
+                scoreTwoCount = countsByScores[2]?.toInt() ?: 0,
+                scoreOneCount = countsByScores[1]?.toInt() ?: 0,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -191,19 +191,19 @@ data class ProductReviewStatisticsResponse(
 
     @Schema(
         description = "만족도",
-        example = "98"
+        example = "60"
     )
     val productSatisfaction: Int,
 
     @Schema(
         description = "후기 총 개수",
-        example = "15"
+        example = "5"
     )
     val totalReviewCount: Int,
 
     @Schema(
         description = "평균 별점",
-        example = "4.3"
+        example = "3.8"
     )
     val averageScore: Double,
 ) {

--- a/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
+++ b/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
@@ -2,6 +2,7 @@ package com.petqua.application.product.review
 
 import com.petqua.application.product.dto.ProductReviewReadQuery
 import com.petqua.application.product.dto.ProductReviewResponse
+import com.petqua.application.product.dto.ProductReviewScoreStatistics
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import com.petqua.domain.product.review.ProductReviewImageRepository
@@ -34,5 +35,12 @@ class ProductReviewService(
         val productReviewIds = reviewsByCondition.map { it.id }
         return productReviewImageRepository.findAllByProductReviewIdIn(productReviewIds).groupBy { it.productReviewId }
             .mapValues { it.value.map { image -> image.imageUrl } }
+    }
+
+    @Transactional(readOnly = true)
+    fun readReviewCountStatistics(productId: Long): ProductReviewScoreStatistics {
+        val countsByScores = productReviewRepository.findReviewScoresWithCount(productId)
+            .associate { it.score to it.count }
+        return ProductReviewScoreStatistics.from(countsByScores)
     }
 }

--- a/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
+++ b/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
@@ -2,11 +2,12 @@ package com.petqua.application.product.review
 
 import com.petqua.application.product.dto.ProductReviewReadQuery
 import com.petqua.application.product.dto.ProductReviewResponse
-import com.petqua.application.product.dto.ProductReviewScoreStatistics
+import com.petqua.application.product.dto.ProductReviewStatisticsResponse
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import com.petqua.domain.product.review.ProductReviewImageRepository
 import com.petqua.domain.product.review.ProductReviewRepository
+import com.petqua.domain.product.review.ProductReviewStatistics
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -38,9 +39,9 @@ class ProductReviewService(
     }
 
     @Transactional(readOnly = true)
-    fun readReviewCountStatistics(productId: Long): ProductReviewScoreStatistics {
-        val countsByScores = productReviewRepository.findReviewScoresWithCount(productId)
-            .associate { it.score to it.count }
-        return ProductReviewScoreStatistics.from(countsByScores)
+    fun readReviewCountStatistics(productId: Long): ProductReviewStatisticsResponse {
+        val reviewScoreWithCounts = productReviewRepository.findReviewScoresWithCount(productId)
+        val productReviewStatistics = ProductReviewStatistics.from(reviewScoreWithCounts)
+        return ProductReviewStatisticsResponse.from(productReviewStatistics)
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/Product.kt
+++ b/src/main/kotlin/com/petqua/domain/product/Product.kt
@@ -2,6 +2,7 @@ package com.petqua.domain.product
 
 import com.petqua.common.domain.BaseEntity
 import com.petqua.common.domain.SoftDeleteEntity
+import com.petqua.domain.product.review.ProductReviewStatistics
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import jakarta.persistence.AttributeOverride
@@ -11,7 +12,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import java.math.BigDecimal
-import java.math.RoundingMode
 
 private const val SCALE = 1
 private const val ZERO = 0
@@ -60,10 +60,7 @@ class Product(
 ) : BaseEntity(), SoftDeleteEntity {
 
     fun averageReviewScore(): Double {
-        return if (reviewCount == ZERO) ZERO.toDouble()
-        else BigDecimal.valueOf(reviewTotalScore / reviewCount.toDouble())
-            .setScale(SCALE, RoundingMode.HALF_UP)
-            .toDouble()
+        return ProductReviewStatistics.averageReviewScore(reviewTotalScore, reviewCount.toDouble())
     }
 
     fun increaseWishCount() {

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -43,3 +43,8 @@ data class ProductReviewWithMemberResponse(
         reviewerYears = reviewer.years,
     )
 }
+
+data class ProductReviewScoreWithCount(
+    val score: Int,
+    val count: Long,
+)

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepository.kt
@@ -2,6 +2,7 @@ package com.petqua.domain.product.review
 
 import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.dto.ProductReviewScoreWithCount
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 
 interface ProductReviewCustomRepository {
@@ -10,4 +11,6 @@ interface ProductReviewCustomRepository {
         condition: ProductReviewReadCondition,
         paging: CursorBasedPaging
     ): List<ProductReviewWithMemberResponse>
+
+    fun findReviewScoresWithCount(productId: Long): List<ProductReviewScoreWithCount>
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.util.createQuery
 import com.petqua.domain.member.Member
 import com.petqua.domain.product.dto.ProductReviewReadCondition
+import com.petqua.domain.product.dto.ProductReviewScoreWithCount
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
@@ -45,6 +46,27 @@ class ProductReviewCustomRepositoryImpl(
             jpqlRenderContext,
             jpqlRenderer,
             paging.limit
+        )
+    }
+
+    override fun findReviewScoresWithCount(productId: Long): List<ProductReviewScoreWithCount> {
+        val query = jpql {
+            selectNew<ProductReviewScoreWithCount>(
+                path(ProductReview::score),
+                count(path(ProductReview::score)),
+            ).from(
+                entity(ProductReview::class),
+            ).where(
+                path(ProductReview::productId).eq(productId),
+            ).groupBy(
+                path(ProductReview::score)
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer
         )
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewStatistics.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewStatistics.kt
@@ -7,7 +7,7 @@ import java.math.RoundingMode
 private const val ZERO = 0
 
 class ProductReviewStatistics private constructor(
-    val reviewCountsByScore: Map<Int, Int>,
+    private val reviewCountsByScore: Map<Int, Int>,
 ) {
 
     companion object {
@@ -15,19 +15,24 @@ class ProductReviewStatistics private constructor(
             val reviewCountsByScore = reviewScoreWithCounts.associate { it.score to it.count.toInt() }
             return ProductReviewStatistics(reviewCountsByScore)
         }
+
+        fun averageReviewScore(reviewTotalScore: Int, totalReviewCount: Double): Double {
+            return if (totalReviewCount == 0.0) 0.0
+            else BigDecimal.valueOf(reviewTotalScore / totalReviewCount)
+                .setScale(1, RoundingMode.HALF_UP)
+                .toDouble()
+        }
     }
 
     val totalReviewCount: Int
         get() = reviewCountsByScore.values.sum()
 
+
     val averageScore: Double
-        get() = if (totalReviewCount == ZERO) ZERO.toDouble()
-        else {
-            val reviewTotalScore = reviewCountsByScore.entries.sumOf { it.key * it.value }
-            BigDecimal.valueOf(reviewTotalScore / totalReviewCount.toDouble())
-                .setScale(1, RoundingMode.HALF_UP)
-                .toDouble()
-        }
+        get() = averageReviewScore(
+            reviewCountsByScore.entries.sumOf { it.key * it.value },
+            totalReviewCount.toDouble()
+        )
 
     val productSatisfaction: Int
         get() = if (totalReviewCount == ZERO) ZERO

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewStatistics.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewStatistics.kt
@@ -1,0 +1,52 @@
+package com.petqua.domain.product.review
+
+import com.petqua.domain.product.dto.ProductReviewScoreWithCount
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+private const val ZERO = 0
+
+class ProductReviewStatistics private constructor(
+    val reviewCountsByScore: Map<Int, Int>,
+) {
+
+    companion object {
+        fun from(reviewScoreWithCounts: List<ProductReviewScoreWithCount>): ProductReviewStatistics {
+            val reviewCountsByScore = reviewScoreWithCounts.associate { it.score to it.count.toInt() }
+            return ProductReviewStatistics(reviewCountsByScore)
+        }
+    }
+
+    val totalReviewCount: Int
+        get() = reviewCountsByScore.values.sum()
+
+    val averageScore: Double
+        get() = if (totalReviewCount == ZERO) ZERO.toDouble()
+        else {
+            val reviewTotalScore = reviewCountsByScore.entries.sumOf { it.key * it.value }
+            BigDecimal.valueOf(reviewTotalScore / totalReviewCount.toDouble())
+                .setScale(1, RoundingMode.HALF_UP)
+                .toDouble()
+        }
+
+    val productSatisfaction: Int
+        get() = if (totalReviewCount == ZERO) ZERO
+        else BigDecimal.valueOf((scoreFiveCount + scoreFourCount) / totalReviewCount.toDouble() * 100)
+            .setScale(0, RoundingMode.HALF_UP)
+            .toInt()
+
+    val scoreFiveCount: Int
+        get() = reviewCountsByScore[5] ?: 0
+
+    val scoreFourCount: Int
+        get() = reviewCountsByScore[4] ?: 0
+
+    val scoreThreeCount: Int
+        get() = reviewCountsByScore[3] ?: 0
+
+    val scoreTwoCount: Int
+        get() = reviewCountsByScore[2] ?: 0
+
+    val scoreOneCount: Int
+        get() = reviewCountsByScore[1] ?: 0
+}

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -1,6 +1,6 @@
 package com.petqua.presentation.product
 
-import com.petqua.application.product.dto.ProductReviewScoreStatistics
+import com.petqua.application.product.dto.ProductReviewStatisticsResponse
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.application.product.review.ProductReviewService
 import com.petqua.presentation.product.dto.ReadAllProductReviewsRequest
@@ -40,7 +40,7 @@ class ProductReviewController(
     @GetMapping("/products/{productId}/review-statistics")
     fun readReviewCountStatistics(
         @PathVariable productId: Long
-    ): ResponseEntity<ProductReviewScoreStatistics> {
+    ): ResponseEntity<ProductReviewStatisticsResponse> {
         val response = productReviewService.readReviewCountStatistics(productId)
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -35,6 +35,8 @@ class ProductReviewController(
         return ResponseEntity.ok(responses)
     }
 
+    @Operation(summary = "상품 후기 통계 조회 API", description = "상품의 후기 통계를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상품 후기 통계 조회 성공")
     @GetMapping("/products/{productId}/review-statistics")
     fun readReviewCountStatistics(
         @PathVariable productId: Long

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -1,5 +1,6 @@
 package com.petqua.presentation.product
 
+import com.petqua.application.product.dto.ProductReviewScoreStatistics
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.application.product.review.ProductReviewService
 import com.petqua.presentation.product.dto.ReadAllProductReviewsRequest
@@ -32,5 +33,13 @@ class ProductReviewController(
             )
         )
         return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/products/{productId}/review-statistics")
+    fun readReviewCountStatistics(
+        @PathVariable productId: Long
+    ): ResponseEntity<ProductReviewScoreStatistics> {
+        val response = productReviewService.readReviewCountStatistics(productId)
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/review/ProductReviewServiceTest.kt
@@ -35,71 +35,70 @@ class ProductReviewServiceTest(
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
-    val store = storeRepository.save(store(name = "펫쿠아"))
-    val member = memberRepository.save(member(nickname = "쿠아"))
-    val product = productRepository.save(
-        product(
-            name = "상품1",
-            storeId = store.id,
-            discountPrice = BigDecimal.ZERO,
-            reviewCount = 0,
-            reviewTotalScore = 0
-        )
-    )
-
-    val savedProductReviews = productReviewRepository.saveAll(
-        listOf(
-            productReview(
-                productId = product.id,
-                reviewerId = member.id,
-                score = 5,
-                recommendCount = 1,
-                hasPhotos = false,
-            ),
-            productReview(
-                productId = product.id,
-                reviewerId = member.id,
-                score = 4,
-                recommendCount = 2,
-                hasPhotos = true,
-            ),
-            productReview(
-                productId = product.id,
-                reviewerId = member.id,
-                score = 3,
-                recommendCount = 3,
-                hasPhotos = false,
-            ),
-            productReview(
-                productId = product.id,
-                reviewerId = member.id,
-                score = 2,
-                recommendCount = 4,
-                hasPhotos = true,
-            ),
-            productReview(
-                productId = product.id,
-                reviewerId = member.id,
-                score = 1,
-                recommendCount = 5,
-                hasPhotos = true,
-            ),
-        )
-    )
-
-    val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
-    productReviewImageRepository.saveAll(
-        listOf(
-            productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
-            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
-            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
-            productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
-            productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
-            productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
-        )
-    )
-
     Given("상품 후기를 조건에 따라") {
+        val store = storeRepository.save(store(name = "펫쿠아"))
+        val member = memberRepository.save(member(nickname = "쿠아"))
+        val product = productRepository.save(
+            product(
+                name = "상품1",
+                storeId = store.id,
+                discountPrice = BigDecimal.ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
+            )
+        )
+
+        val savedProductReviews = productReviewRepository.saveAll(
+            listOf(
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 1,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 4,
+                    recommendCount = 2,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 3,
+                    recommendCount = 3,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 4,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 1,
+                    recommendCount = 5,
+                    hasPhotos = true,
+                ),
+            )
+        )
+
+        val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
+        productReviewImageRepository.saveAll(
+            listOf(
+                productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
+                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
+            )
+        )
 
         When("전체 별점, 최신순으로 조회 하면") {
             val query = ProductReviewReadQuery(
@@ -173,6 +172,74 @@ class ProductReviewServiceTest(
                     size shouldBe 1
                     shouldBeSortedWith(compareByDescending { it.recommendCount })
                     forAll { it.score shouldBe 3 }
+                }
+            }
+        }
+    }
+
+    Given("상품 후기의 점수별 개수를 조회 할 때") {
+        val store = storeRepository.save(store(name = "펫쿠아"))
+        val member = memberRepository.save(member(nickname = "쿠아"))
+        val product = productRepository.save(
+            product(
+                name = "상품1",
+                storeId = store.id,
+                discountPrice = BigDecimal.ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
+            )
+        )
+
+        val savedProductReviews = productReviewRepository.saveAll(
+            listOf(
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 1,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 2,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 3,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 4,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 5,
+                    hasPhotos = true,
+                ),
+            )
+        )
+
+        When("상품 ID를 입력 하면") {
+            val response = productReviewService.readReviewCountStatistics(product.id)
+
+            Then("점수별 개수를 반환한다") {
+                assertSoftly(response) {
+                    scoreFiveCount shouldBe 3
+                    scoreFourCount shouldBe 0
+                    scoreThreeCount shouldBe 0
+                    scoreTwoCount shouldBe 2
+                    scoreOneCount shouldBe 0
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImplTest.kt
@@ -162,6 +162,72 @@ class ProductReviewCustomRepositoryImplTest(
         }
     }
 
+    Given("상품 후기의 점수별 개수를 조회 할 때") {
+        val store = storeRepository.save(store(name = "펫쿠아"))
+        val member = memberRepository.save(member(nickname = "쿠아"))
+        val product = productRepository.save(
+            product(
+                name = "상품1",
+                storeId = store.id,
+                discountPrice = BigDecimal.ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
+            )
+        )
+
+        productReviewRepository.saveAll(
+            listOf(
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 1,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 2,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 5,
+                    recommendCount = 3,
+                    hasPhotos = false,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 4,
+                    hasPhotos = true,
+                ),
+                productReview(
+                    productId = product.id,
+                    reviewerId = member.id,
+                    score = 2,
+                    recommendCount = 5,
+                    hasPhotos = true,
+                ),
+            )
+        )
+
+        When("상품 후기의 점수별 개수를 조회 하면") {
+            val productReviewScoreWithCount = productReviewRepository.findReviewScoresWithCount(product.id)
+
+            Then("점수별 개수를 반환 한다") {
+                assertSoftly(productReviewScoreWithCount) {
+                    size shouldBe 2
+                    find { it.score == 5 }?.count shouldBe 3
+                    find { it.score == 2 }?.count shouldBe 2
+                }
+            }
+        }
+    }
+
     afterContainer {
         dataCleaner.clean()
     }

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewStatisticsTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewStatisticsTest.kt
@@ -1,0 +1,30 @@
+package com.petqua.domain.product.review
+
+import com.petqua.domain.product.dto.ProductReviewScoreWithCount
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ProductReviewStatisticsTest : StringSpec({
+    "상품 후기 통계 생성" {
+        val reviewScoreWithCounts = listOf(
+            ProductReviewScoreWithCount(5, 3),
+            ProductReviewScoreWithCount(4, 2),
+            ProductReviewScoreWithCount(2, 1),
+            ProductReviewScoreWithCount(1, 1),
+        )
+
+        val statistics = ProductReviewStatistics.from(reviewScoreWithCounts)
+
+        assertSoftly(statistics) {
+            totalReviewCount shouldBe 7
+            averageScore shouldBe 3.7
+            productSatisfaction shouldBe 71
+            scoreFiveCount shouldBe 3
+            scoreFourCount shouldBe 2
+            scoreThreeCount shouldBe 0
+            scoreTwoCount shouldBe 1
+            scoreOneCount shouldBe 1
+        }
+    }
+})

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerSteps.kt
@@ -1,3 +1,5 @@
+package com.petqua.presentation.product
+
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import io.restassured.module.kotlin.extensions.Extract
@@ -27,6 +29,18 @@ fun requestReadAllReviewProducts(
         pathParam("productId", productId)
     } When {
         get("/products/{productId}/reviews")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}
+
+fun requestReadProductReviewCount(productId: Long): Response {
+    return Given {
+        log().all()
+    } When {
+        get("/products/{productId}/review-statistics", productId)
     } Then {
         log().all()
     } Extract {

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
@@ -1,6 +1,6 @@
 package com.petqua.presentation.product
 
-import com.petqua.application.product.dto.ProductReviewScoreStatistics
+import com.petqua.application.product.dto.ProductReviewStatisticsResponse
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
@@ -150,7 +150,7 @@ class ProductReviewControllerTest(
             }
         }
 
-        Given("상품 후기의 점수별 개수를 조회 할 때") {
+        Given("상품 후기의 통계를 조회 할 때") {
             val store = storeRepository.save(store(name = "펫쿠아"))
             val member = memberRepository.save(member(nickname = "쿠아"))
             val product = productRepository.save(
@@ -203,11 +203,11 @@ class ProductReviewControllerTest(
                 )
             )
 
-            When("상품 후기의 점수별 개수를 조회 하면") {
+            When("상품 후기의 통계를 조회 하면") {
                 val response = requestReadProductReviewCount(productId = product.id)
 
-                Then("해당 상품의 후기 점수별 개수를 반환한다") {
-                    val responseBody = response.`as`(ProductReviewScoreStatistics::class.java)
+                Then("해당 상품의 후기 점수별 개수와 만족도, 평균 별점, 총 별점 수를 반환한다") {
+                    val responseBody = response.`as`(ProductReviewStatisticsResponse::class.java)
 
                     assertSoftly(responseBody) {
                         scoreFiveCount shouldBe 3
@@ -215,6 +215,9 @@ class ProductReviewControllerTest(
                         scoreThreeCount shouldBe 0
                         scoreTwoCount shouldBe 2
                         scoreOneCount shouldBe 0
+                        totalReviewCount shouldBe 5
+                        productSatisfaction shouldBe 60
+                        averageScore shouldBe 3.8
                     }
                 }
             }

--- a/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductReviewControllerTest.kt
@@ -1,5 +1,6 @@
 package com.petqua.presentation.product
 
+import com.petqua.application.product.dto.ProductReviewScoreStatistics
 import com.petqua.application.product.dto.ProductReviewsResponse
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
@@ -18,7 +19,6 @@ import io.kotest.matchers.collections.shouldBeSortedWith
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
-import requestReadAllReviewProducts
 
 class ProductReviewControllerTest(
     private val memberRepository: MemberRepository,
@@ -28,72 +28,70 @@ class ProductReviewControllerTest(
     private val productReviewImageRepository: ProductReviewImageRepository,
 ) : ApiTestConfig() {
     init {
-
-        val store = storeRepository.save(store(name = "펫쿠아"))
-        val member = memberRepository.save(member(nickname = "쿠아"))
-        val product = productRepository.save(
-            product(
-                name = "상품1",
-                storeId = store.id,
-                discountPrice = BigDecimal.ZERO,
-                reviewCount = 0,
-                reviewTotalScore = 0
-            )
-        )
-
-        val savedProductReviews = productReviewRepository.saveAll(
-            listOf(
-                productReview(
-                    productId = product.id,
-                    reviewerId = member.id,
-                    score = 5,
-                    recommendCount = 1,
-                    hasPhotos = false,
-                ),
-                productReview(
-                    productId = product.id,
-                    reviewerId = member.id,
-                    score = 4,
-                    recommendCount = 2,
-                    hasPhotos = true,
-                ),
-                productReview(
-                    productId = product.id,
-                    reviewerId = member.id,
-                    score = 3,
-                    recommendCount = 3,
-                    hasPhotos = false,
-                ),
-                productReview(
-                    productId = product.id,
-                    reviewerId = member.id,
-                    score = 2,
-                    recommendCount = 4,
-                    hasPhotos = true,
-                ),
-                productReview(
-                    productId = product.id,
-                    reviewerId = member.id,
-                    score = 1,
-                    recommendCount = 5,
-                    hasPhotos = true,
-                ),
-            )
-        )
-
-        val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
-        productReviewImageRepository.saveAll(
-            listOf(
-                productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
-                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
-                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
-                productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
-                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
-                productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
-            )
-        )
-
         Given("조건에 따라 상품 후기를 조회 하면") {
+            val store = storeRepository.save(store(name = "펫쿠아"))
+            val member = memberRepository.save(member(nickname = "쿠아"))
+            val product = productRepository.save(
+                product(
+                    name = "상품1",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.ZERO,
+                    reviewCount = 0,
+                    reviewTotalScore = 0
+                )
+            )
+
+            val savedProductReviews = productReviewRepository.saveAll(
+                listOf(
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 5,
+                        recommendCount = 1,
+                        hasPhotos = false,
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 4,
+                        recommendCount = 2,
+                        hasPhotos = true,
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 3,
+                        recommendCount = 3,
+                        hasPhotos = false,
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 2,
+                        recommendCount = 4,
+                        hasPhotos = true,
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 1,
+                        recommendCount = 5,
+                        hasPhotos = true,
+                    ),
+                )
+            )
+
+            val hasPhotoReviewIds = savedProductReviews.filter { it.hasPhotos }.map { it.id } // total 3
+            productReviewImageRepository.saveAll(
+                listOf(
+                    productReviewImage(productReviewId = hasPhotoReviewIds[0], imageUrl = "imageUrl1-1"),
+                    productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-1"),
+                    productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-2"),
+                    productReviewImage(productReviewId = hasPhotoReviewIds[1], imageUrl = "imageUrl2-3"),
+                    productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-1"),
+                    productReviewImage(productReviewId = hasPhotoReviewIds[2], imageUrl = "imageUrl3-2"),
+                )
+            )
 
             When("전체 별점, 최신순으로 조회 하면") {
 
@@ -147,6 +145,76 @@ class ProductReviewControllerTest(
                     assertSoftly(responseBody.productReviews) {
                         size shouldBe 1
                         forAll { it.score shouldBe 3 }
+                    }
+                }
+            }
+        }
+
+        Given("상품 후기의 점수별 개수를 조회 할 때") {
+            val store = storeRepository.save(store(name = "펫쿠아"))
+            val member = memberRepository.save(member(nickname = "쿠아"))
+            val product = productRepository.save(
+                product(
+                    name = "상품1",
+                    storeId = store.id,
+                    discountPrice = BigDecimal.ZERO,
+                    reviewCount = 0,
+                    reviewTotalScore = 0
+                )
+            )
+
+            productReviewRepository.saveAll(
+                listOf(
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 5,
+                        recommendCount = 1,
+                        hasPhotos = false
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 5,
+                        recommendCount = 2,
+                        hasPhotos = true
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 5,
+                        recommendCount = 3,
+                        hasPhotos = false
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 2,
+                        recommendCount = 4,
+                        hasPhotos = true
+                    ),
+                    productReview(
+                        productId = product.id,
+                        reviewerId = member.id,
+                        score = 2,
+                        recommendCount = 5,
+                        hasPhotos = true
+                    ),
+                )
+            )
+
+            When("상품 후기의 점수별 개수를 조회 하면") {
+                val response = requestReadProductReviewCount(productId = product.id)
+
+                Then("해당 상품의 후기 점수별 개수를 반환한다") {
+                    val responseBody = response.`as`(ProductReviewScoreStatistics::class.java)
+
+                    assertSoftly(responseBody) {
+                        scoreFiveCount shouldBe 3
+                        scoreFourCount shouldBe 0
+                        scoreThreeCount shouldBe 0
+                        scoreTwoCount shouldBe 2
+                        scoreOneCount shouldBe 0
                     }
                 }
             }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #52 

### 📁 작업 설명
<img width="339" alt="Screenshot 2024-02-09 at 00 06 48" src="https://github.com/petqua/backend/assets/90550065/936aa567-e437-4c42-8992-a851dfce66f4">

상품 후기 통계 조회 API 구현
- 상품 후기 데이터를 score로 groupBy 하여 개수를 집계하였습니다.
~- 만족도와 전체 후기 개수는 주어진 데이터로 계산 가능하다고 판단하여 응답에 포함하지 않았습니다.~
- 만족도와 전체 후기 개수, 별점 평균을 포함하여 응답합니다.
만족도는 전체 별점 중 4, 5 점 별점의 비율입니다.

### 📸 작업화면
<!-- 내용이 포함되지 않으면 제거 -->
응답 예시
```json
{
    "scoreFiveCount": 3,
    "scoreFourCount": 0,
    "scoreThreeCount": 0,
    "scoreTwoCount": 2,
    "scoreOneCount": 0,
    "productSatisfaction": 60,
    "totalReviewCount": 5,
    "averageScore": 3.8
}
```
### 기타
- on #64 
응답 필드에 대한 네이밍이 괜찮으신가요...?
