### PR TITLE
feature: 로깅 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     // kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("ch.qos.logback:logback-access")
+
 
     // spring data jpa
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,6 @@ dependencies {
     // kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("ch.qos.logback:logback-access")
-
 
     // spring data jpa
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -50,6 +48,10 @@ dependencies {
 
     // swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
+    // logging
+    implementation("ch.qos.logback:logback-access")
+    implementation("org.codehaus.janino:janino:3.1.6")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")

--- a/src/main/kotlin/com/petqua/common/config/AccessLogConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/AccessLogConfig.kt
@@ -1,33 +1,21 @@
 package com.petqua.common.config
 
 import ch.qos.logback.access.tomcat.LogbackValve
-import org.apache.catalina.Context
-import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
-import org.springframework.boot.web.server.WebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ResourceLoader
 
 
 @Configuration
-class AccessLogConfig(
-    private val resourceLoader: ResourceLoader
-) {
+class AccessLogConfig {
 
     @Bean
-    fun webServerFactoryCustomizer(): WebServerFactoryCustomizer<*> {
-        return WebServerFactoryCustomizer { container: WebServerFactory? ->
-            if (container is TomcatServletWebServerFactory) {
-                container.addContextCustomizers(TomcatContextCustomizer { context: Context ->
-                    val valve = LogbackValve()
-                    valve.filename = resourceLoader
-                        .getResource(ResourceLoader.CLASSPATH_URL_PREFIX + "logback-access.xml")
-                        .filename
-                    context.pipeline.addValve(valve)
-                })
-            }
+    fun webServerFactoryCustomizer(): WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+        return WebServerFactoryCustomizer<TomcatServletWebServerFactory> { factory ->
+            val logbackValve = LogbackValve()
+            logbackValve.filename = "logback-access.xml"
+            factory.addContextValves(logbackValve)
         }
     }
 }

--- a/src/main/kotlin/com/petqua/common/config/AccessLogConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/AccessLogConfig.kt
@@ -1,0 +1,33 @@
+package com.petqua.common.config
+
+import ch.qos.logback.access.tomcat.LogbackValve
+import org.apache.catalina.Context
+import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.boot.web.server.WebServerFactory
+import org.springframework.boot.web.server.WebServerFactoryCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ResourceLoader
+
+
+@Configuration
+class AccessLogConfig(
+    private val resourceLoader: ResourceLoader
+) {
+
+    @Bean
+    fun webServerFactoryCustomizer(): WebServerFactoryCustomizer<*> {
+        return WebServerFactoryCustomizer { container: WebServerFactory? ->
+            if (container is TomcatServletWebServerFactory) {
+                container.addContextCustomizers(TomcatContextCustomizer { context: Context ->
+                    val valve = LogbackValve()
+                    valve.filename = resourceLoader
+                        .getResource(ResourceLoader.CLASSPATH_URL_PREFIX + "logback-access.xml")
+                        .filename
+                    context.pipeline.addValve(valve)
+                })
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/common/config/MdcFilter.kt
+++ b/src/main/kotlin/com/petqua/common/config/MdcFilter.kt
@@ -1,0 +1,23 @@
+package com.petqua.common.config
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import java.util.*
+
+private const val REQUEST_ID = "requestId"
+
+@Component
+class MdcFilter : Filter {
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        val requestId = UUID.randomUUID().toString()
+        MDC.put(REQUEST_ID, requestId)
+        request.setAttribute(REQUEST_ID, requestId)
+        chain.doFilter(request, response)
+        MDC.clear();
+    }
+}

--- a/src/main/kotlin/com/petqua/common/exception/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/petqua/common/exception/ExceptionControllerAdvice.kt
@@ -16,7 +16,7 @@ class ExceptionControllerAdvice {
     @ExceptionHandler(BaseException::class)
     fun handleBaseException(request: HttpServletRequest, e: BaseException): ResponseEntity<ExceptionResponse> {
         val type = e.exceptionType()
-        log.warn("잘못된 요청이 들어왔습니다. URI: ${request.requestURI},  내용:  ${type.errorMessage()}")
+        log.warn("잘못된 요청이 들어왔습니다. URI: ${request.requestURI}, 코드: ${type.code()}, 내용:  ${type.errorMessage()}")
         return ResponseEntity.status(type.httpStatus()).body(
             ExceptionResponse(
                 code = type.code(),

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+${DATE_SEC} [%thread] %clr(%5level) %cyan(%logger) - %msg
+%ex
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/error-appender.xml
+++ b/src/main/resources/error-appender.xml
@@ -1,0 +1,28 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <file>../logs/error/${DATE}.log</file>
+        <encoder>
+            <pattern>
+[requestId: %X{requestId:-NO REQUEST ID}]
+timestamp: ${DATE_SEC},
+message: %message,
+exception: %ex
+%n
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>../logs/backup/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/info-appender.xml
+++ b/src/main/resources/info-appender.xml
@@ -1,0 +1,27 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <file>../logs/info/${DATE}.log</file>
+        <encoder>
+            <pattern>
+[requestId: %X{requestId:-NO REQUEST ID}]
+timestamp: ${DATE_SEC},
+message: %message
+%n
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>../logs/backup/info/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,36 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProfile name="prod">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
-    <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
+        <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
+        <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
 
-    <appender name="FILE-ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>event.getStatusCode() >= 400</expression>
-            </evaluator>
-            <onMismatch>DENY</onMismatch>
-        </filter>
+        <appender name="FILE-ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+                <evaluator>
+                    <expression>event.getStatusCode() >= 400</expression>
+                </evaluator>
+                <onMismatch>DENY</onMismatch>
+            </filter>
 
-        <file>../logs/access/${DATE}.log</file>
-        <encoder>
-            <pattern>
+            <file>../logs/access/${DATE}.log</file>
+            <encoder>
+                <pattern>
 [requestId: %reqAttribute{requestId}]
 timestamp: ${DATE_SEC},
 %fullRequest
 %n
-            </pattern>
-            <charset>utf8</charset>
-        </encoder>
+                </pattern>
+                <charset>utf8</charset>
+            </encoder>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>../logs/backup/access/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>7</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>../logs/backup/access/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
 
-    <appender-ref ref="FILE-ACCESS" />
+        <appender-ref ref="FILE-ACCESS" />
+    </springProfile>
 </configuration>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -6,6 +6,13 @@
     <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
 
     <appender name="FILE-ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <expression>event.getStatusCode() >= 400</expression>
+            </evaluator>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
         <file>../logs/access/${DATE}.log</file>
         <encoder>
             <pattern>
@@ -19,9 +26,9 @@ timestamp: ${DATE_SEC},
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>../logs/backup/access/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-            <maxHistory>10</maxHistory>
-            <totalSizeCap>100MB</totalSizeCap>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
+    <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
+
+    <appender name="FILE-ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>../logs/access/${DATE}.log</file>
+        <encoder>
+            <pattern>
+timestamp: ${DATE_SEC},
+%fullRequest
+%n
+            </pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>../logs/backup/access/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <appender-ref ref="FILE-ACCESS" />
+</configuration>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -9,6 +9,7 @@
         <file>../logs/access/${DATE}.log</file>
         <encoder>
             <pattern>
+[requestId: %reqAttribute{requestId}]
 timestamp: ${DATE_SEC},
 %fullRequest
 %n

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -14,6 +14,7 @@ timestamp: ${DATE_SEC},
 %fullRequest
 %n
             </pattern>
+            <charset>utf8</charset>
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,11 +5,13 @@
     <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
     <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
 
+    <include resource="console-appender.xml"/>
     <include resource="info-appender.xml"/>
     <include resource="warn-appender.xml"/>
     <include resource="error-appender.xml"/>
 
     <root level="info">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE-INFO"/>
         <appender-ref ref="FILE-ERROR"/>
         <appender-ref ref="FILE-WARN"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
+    <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
+
+    <include resource="info-appender.xml"/>
+    <include resource="warn-appender.xml"/>
+    <include resource="error-appender.xml"/>
+
+    <root level="info">
+        <appender-ref ref="FILE-INFO"/>
+        <appender-ref ref="FILE-ERROR"/>
+        <appender-ref ref="FILE-WARN"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProfile name="prod">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
-    <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
+        <timestamp key="DATE" datePattern="yyyy-MM-dd"/>
+        <timestamp key="DATE_SEC" datePattern="yyyy-MM-dd HH:mm:ss"/>
 
-    <include resource="console-appender.xml"/>
-    <include resource="info-appender.xml"/>
-    <include resource="warn-appender.xml"/>
-    <include resource="error-appender.xml"/>
+        <include resource="console-appender.xml"/>
+        <include resource="info-appender.xml"/>
+        <include resource="warn-appender.xml"/>
+        <include resource="error-appender.xml"/>
 
-    <root level="info">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE-INFO"/>
-        <appender-ref ref="FILE-ERROR"/>
-        <appender-ref ref="FILE-WARN"/>
-    </root>
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="FILE-WARN"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/src/main/resources/warn-appender.xml
+++ b/src/main/resources/warn-appender.xml
@@ -1,0 +1,27 @@
+<included>
+    <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <file>../logs/warn/${DATE}.log</file>
+        <encoder>
+            <pattern>
+[requestId: %X{requestId:-NO REQUEST ID}]
+timestamp: ${DATE_SEC},
+message: %message
+%n
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>../logs/backup/warn/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #68

### 📁 작업 설명
로깅을 추가해보았습니다! 로거가 총 다섯 개 있어요
* `CONSOLE` :  모든 레벨의 로그를 콘솔에서 출력
* `FILE-ACCESS` : HTTP Request와 관련된 로그를 파일로 생성(HTTP status code가 400번 이상일 때만 로깅)
* `FILE-INFO` : INFO 레벨 로그를 파일로 생성
* `FILE-WARN` : WARN 레벨 로그를 파일로 생성
* `FILE-ERROR` : ERROR 레벨 로그를 파일로 생성(에러 스택 트레이스 전부 출력)

### 📸 작업화면(선택)

#### `CONSOLE` 로그 포맷
<img width="1282" alt="스크린샷 2024-02-13 오전 5 20 54" src="https://github.com/petqua/backend/assets/65850682/ce83100f-6424-49a0-85d3-64540a5ca302">


#### `FILE-ACCESS` 로그 포맷
```
[requestId: 1930dbf2-e3c0-4171-ab13-7b21671e065d]
timestamp: 2024-02-13 04:56:47,
DELETE /carts/1 HTTP/1.1
content-type: application/json
authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6IjIiLCJhdXRob3JpdHkiOiJNRU1CRVIiLCJpYXQiOjE3MDc3Njc4MjAsImV4cCI6MTcwNzc3MTQyMH0._ZZPlet59ljlnoZ7DBP5Rec2BDM4gqcNTBNGCwUZJ_w
accept: */*
host: localhost:52584
connection: Keep-Alive
user-agent: Apache-HttpClient/4.5.13 (Java/18.0.2)
accept-encoding: gzip,deflate
cookie: refresh-token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6IjIiLCJhdXRob3JpdHkiOiJNRU1CRVIiLCJpYXQiOjE3MDc3Njc4MjAsImV4cCI6MTcwNzc3MTQyMH0._ZZPlet59ljlnoZ7DBP5Rec2BDM4gqcNTBNGCwUZJ_w
```

#### INFO & WARN 로그 포맷
```
[requestId: 15044468-1259-4ad0-af5a-3995173773bd]
timestamp: 2024-02-13 03:36:27,
message: 잘못된 요청이 들어왔습니다. URI: /products/wishes, 코드: A12, 내용:  올바른 형태의 Authorization 헤더가 아닙니다.
```

#### ERROR 로그 포맷
```
[requestId: 1812d295-f30c-4887-8e86-3cd8cba85a62]
timestamp: 2024-02-13 03:36:27,
message: 예상하지 못한 예외가 발생했습니다. URI: /favicon.ico, No static resource favicon.ico.,
exception: org.springframework.web.servlet.resource.NoResourceFoundException: No static resource favicon.ico.
	at org.springframework.web.servlet.resource.ResourceHttpRequestHandler.handleRequest(ResourceHttpRequestHandler.java:585)
	(편의상 줄임)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:833)
```


### HTTP Request 정보 로깅
HTTP Request를 로깅하면 디버깅할 때 편리할 것 같아서 추가했습니다!
구현 방법 후보가 두 개 있었는데,
1. `logback access` 사용
2. request header등 데이터를 추출해서 `MDC`에 넣고, INFO, WARN, ERROR로그를 출력할 때 함께 출력한다.

둘 중 `logback access`를 사용했는데, 이유는
* MDC와 달리 이미 만들어진 로그 포맷을 바로 사용할 수 있고,
* thread local에 데이터를 저장해야하는 MDC보다 성능이 더 좋을거라... 생각했습니다...

근데... 단점이 있어요
1. 의존성 두 개 추가됨
```
    implementation("ch.qos.logback:logback-access") // 디폴트로 추가
    implementation("org.codehaus.janino:janino:3.1.6") // access로그 출력 조건을 지정하기 위해 추가
```

2. AccessLogConfig 클래스 하나 추가됨
3. 로그 레벨별로 나누는 게 불가능해서 INFO, WARN, ERROR 로그 폴더가 아닌 별도의 폴더에서 로그 파일을 생성해야함(일단 로그마다 RequestId가 있으니 큰 단점이라고 생각은 안했음...)

네... 그렇습니다...  
`logback access`별로인 것 같다~ 그냥 HTTP Request정보도 MDC에서 출력하게 하자! or 그냥 Request정보 출력하지 말자 등 다양한 의견 부탁드립니닷... 
그 외 로그 포맷등 다양한 의견 대환영~...


