### PR TITLE
refactor: 카테고리 조회 상품 상세 조회 api swagger 반영

### DIFF
--- a/src/main/kotlin/com/petqua/application/product/category/CategoryDto.kt
+++ b/src/main/kotlin/com/petqua/application/product/category/CategoryDto.kt
@@ -3,6 +3,7 @@ package com.petqua.application.product.category
 import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.Sorter
 import com.petqua.domain.product.Sorter.NONE
@@ -24,6 +25,7 @@ data class CategoryProductReadQuery(
     val sorter: Sorter = NONE,
     val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
     val limit: Int = PAGING_LIMIT_CEILING,
+    val loginMemberOrGuest: LoginMemberOrGuest,
 ) {
     fun toCondition(): CategoryProductReadCondition {
         return CategoryProductReadCondition.of(

--- a/src/main/kotlin/com/petqua/application/product/category/CategoryService.kt
+++ b/src/main/kotlin/com/petqua/application/product/category/CategoryService.kt
@@ -1,8 +1,11 @@
 package com.petqua.application.product.category
 
 import com.petqua.application.product.dto.ProductsResponse
+import com.petqua.domain.auth.LoginMemberOrGuest
+import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.category.SpeciesResponse
+import com.petqua.domain.product.dto.ProductResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CategoryService(
     private val categoryRepository: CategoryRepository,
+    private val wishProductRepository: WishProductRepository,
 ) {
 
     @Transactional(readOnly = true)
@@ -21,7 +25,22 @@ class CategoryService(
     @Transactional(readOnly = true)
     fun readProducts(query: CategoryProductReadQuery): ProductsResponse {
         val products = categoryRepository.findProductsByCategoryCondition(query.toCondition(), query.toPaging())
+        val markedProducts = markWishedProductOf(query.loginMemberOrGuest, products)
         val totalProductsCount = categoryRepository.countProductsByCategoryCondition(query.toCondition())
-        return ProductsResponse.of(products, query.limit, totalProductsCount)
+        return ProductsResponse.of(markedProducts, query.limit, totalProductsCount)
+    }
+
+    private fun markWishedProductOf(
+        loginMemberOrGuest: LoginMemberOrGuest,
+        products: List<ProductResponse>
+    ): List<ProductResponse> {
+        if (loginMemberOrGuest.isMember()) {
+            val wishedProductsIds = wishProductRepository.findWishedProductIdByMemberIdAndProductIdIn(
+                memberId = loginMemberOrGuest.memberId,
+                productIds = products.map { it.id }
+            )
+            return products.map { it.copy(isWished = wishedProductsIds.contains(it.id)) }
+        }
+        return products
     }
 }

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -10,6 +10,8 @@ import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.WishCount
+import com.petqua.domain.product.WishProduct
+import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.Category
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.category.Family
@@ -62,11 +64,21 @@ class DataInitializer(
     private val productInfoRepository: ProductInfoRepository,
     private val productImageRepository: ProductImageRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val wishProductRepository: WishProductRepository,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
     @Transactional
     fun setUpData() {
+        // member
+        val member = memberRepository.save(
+            Member(
+                oauthId = "oauthId",
+                oauthServerNumber = 1,
+                authority = MEMBER,
+            )
+        )
+
         // announcement
         val announcement1 = Announcement(
             title = "[공지] 펫쿠아 프론트엔드 개발자 구인 중!",
@@ -161,7 +173,7 @@ class DataInitializer(
             canPickUp = true,
         )
         productRepository.saveAll(listOf(product1, product2, product3))
-        saveProducts(store1.id, category1.id)
+        saveProducts(store1.id, category1.id, member.id)
 
         // productRecommendation
         val productRecommendation1 = ProductRecommendation(productId = product3.id)
@@ -264,15 +276,6 @@ class DataInitializer(
             )
         )
 
-        // member
-        val member = memberRepository.save(
-            Member(
-                oauthId = "oauthId",
-                oauthServerNumber = 1,
-                authority = MEMBER,
-            )
-        )
-
         // productReview
         val reviews = productReviewRepository.saveAll(
             listOf(
@@ -310,7 +313,7 @@ class DataInitializer(
         }
     }
 
-    private fun saveProducts(storeId: Long, categoryId: Long) {
+    private fun saveProducts(storeId: Long, categoryId: Long, memberId: Long) {
         val products = (1..100).map {
             Product(
                 name = "니모를 찾아서 세트$it",
@@ -330,5 +333,15 @@ class DataInitializer(
             )
         }
         productRepository.saveAll(products)
+
+        val wishProducts = products.filter {
+            (it.id % 2).toInt() == 0
+        }.map {
+            WishProduct(
+                productId = it.id,
+                memberId = memberId
+            )
+        }
+        wishProductRepository.saveAll(wishProducts)
     }
 }

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -5,6 +5,8 @@ import com.petqua.domain.announcement.AnnouncementRepository
 import com.petqua.domain.auth.Authority.MEMBER
 import com.petqua.domain.banner.Banner
 import com.petqua.domain.banner.BannerRepository
+import com.petqua.domain.keyword.ProductKeyword
+import com.petqua.domain.keyword.ProductKeywordRepository
 import com.petqua.domain.member.Member
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.Product
@@ -16,18 +18,13 @@ import com.petqua.domain.product.category.Category
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.category.Family
 import com.petqua.domain.product.category.Species
-import com.petqua.domain.product.detail.DifficultyLevel.EASY
-import com.petqua.domain.product.detail.DifficultyLevel.HARD
 import com.petqua.domain.product.detail.DifficultyLevel.NORMAL
-import com.petqua.domain.product.detail.OptimalTankSize.TANK1
 import com.petqua.domain.product.detail.OptimalTankSize.TANK2
-import com.petqua.domain.product.detail.OptimalTankSize.TANK3
 import com.petqua.domain.product.detail.OptimalTemperature
 import com.petqua.domain.product.detail.ProductImage
 import com.petqua.domain.product.detail.ProductImageRepository
 import com.petqua.domain.product.detail.ProductInfo
 import com.petqua.domain.product.detail.ProductInfoRepository
-import com.petqua.domain.product.detail.Temperament.AGGRESSIVE
 import com.petqua.domain.product.detail.Temperament.PEACEFUL
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.product.option.ProductOptionRepository
@@ -65,277 +62,129 @@ class DataInitializer(
     private val productImageRepository: ProductImageRepository,
     private val productOptionRepository: ProductOptionRepository,
     private val wishProductRepository: WishProductRepository,
+    private val productKeywordRepository: ProductKeywordRepository,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
     @Transactional
     fun setUpData() {
         // member
-        val member = memberRepository.save(
+        val member = saveMember()
+
+        // announcement
+        saveAnnouncements()
+
+        // banner
+        saveBanners()
+
+        // others
+        saveCommerceData(member.id)
+    }
+
+    private fun saveMember(): Member {
+        return memberRepository.save(
             Member(
                 oauthId = "oauthId",
                 oauthServerNumber = 1,
                 authority = MEMBER,
             )
         )
+    }
 
-        // announcement
-        val announcement1 = Announcement(
-            title = "[공지] 펫쿠아 프론트엔드 개발자 구인 중!",
-            linkUrl = "https://team.petqua.co.kr/"
+    private fun saveAnnouncements() {
+        announcementRepository.saveAll(
+            listOf(
+                Announcement(
+                    title = "[공지] 펫쿠아 프론트엔드 개발자 구인 중!",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+                Announcement(
+                    title = "[공지] 펫쿠아 복지 추가 GPT4 지원 예정",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+                Announcement(
+                    title = "[공지] 펫쿠아 개발팀 copilot 적극 활용",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+            )
         )
-        val announcement2 = Announcement(
-            title = "[공지] 펫쿠아 복지 추가 GPT4 지원 예정",
-            linkUrl = "https://team.petqua.co.kr/"
-        )
-        val announcement3 = Announcement(
-            title = "[공지] 펫쿠아 개발팀 copilot 적극 활용",
-            linkUrl = "https://team.petqua.co.kr/"
-        )
-        announcementRepository.saveAll(listOf(announcement1, announcement2, announcement3))
+    }
 
-        // banner
-        val banner1 = Banner(
-            imageUrl = "https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg",
-            linkUrl = "https://team.petqua.co.kr/"
+    private fun saveBanners() {
+        bannerRepository.saveAll(
+            listOf(
+                Banner(
+                    imageUrl = "https://docs.petqua.co.kr/banners/b08f14d5ac00721b.jpg",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+                Banner(
+                    imageUrl = "https://docs.petqua.co.kr/banners/announcement1.jpg",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+                Banner(
+                    imageUrl = "https://docs.petqua.co.kr/banners/announcement2.jpg",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+                Banner(
+                    imageUrl = "https://docs.petqua.co.kr/banners/announcement3.jpg",
+                    linkUrl = "https://team.petqua.co.kr/"
+                ),
+            )
         )
-        val banner2 = Banner(
-            imageUrl = "https://docs.petqua.co.kr/banners/announcement1.jpg",
-            linkUrl = "https://team.petqua.co.kr/"
-        )
-        val banner3 = Banner(
-            imageUrl = "https://docs.petqua.co.kr/banners/announcement2.jpg",
-            linkUrl = "https://team.petqua.co.kr/"
-        )
-        val banner4 = Banner(
-            imageUrl = "https://docs.petqua.co.kr/banners/announcement3.jpg",
-            linkUrl = "https://team.petqua.co.kr/"
-        )
-        bannerRepository.saveAll(listOf(banner1, banner2, banner3, banner4))
+    }
 
+    private fun saveCommerceData(memberId: Long) {
         // store
-        val store1 = Store(name = "니모를 찾아서")
-        val store2 = Store(name = "제주 미영이네 식당")
-        storeRepository.saveAll(listOf(store1, store2))
+        val store = Store(name = "상점1")
+        storeRepository.saveAll(listOf(store))
 
         // category
         val category1 = Category(family = Family("송사리과"), species = Species("고정구피"))
         val category2 = Category(family = Family("송사리과"), species = Species("팬시구피"))
         categoryRepository.saveAll(listOf(category1, category2))
 
-        // product
-        val product1 = Product(
-            name = "니모",
-            categoryId = category1.id,
-            price = BigDecimal.valueOf(30000L).setScale(2),
-            storeId = store1.id,
-            discountRate = 10,
-            discountPrice = BigDecimal(27000L).setScale(2),
-            wishCount = WishCount(3),
-            reviewCount = 10,
-            reviewTotalScore = 50,
-            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg",
-            description = "https://www.goldmoonaqua.com/web/upload/NNEditor/20221226/copy-1672038777-guppy_EC958CEBB984EB85B8ED9280EBA088EB939C_02.png",
-            canDeliverSafely = false,
-            canDeliverCommonly = true,
-            canPickUp = false,
-        )
-        val product2 = Product(
-            name = "참고등어",
-            categoryId = category2.id,
-            price = BigDecimal.valueOf(20000L).setScale(2),
-            storeId = store1.id,
-            discountRate = 10,
-            discountPrice = BigDecimal(18000L).setScale(2),
-            wishCount = WishCount(5),
-            reviewCount = 3,
-            reviewTotalScore = 15,
-            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg",
-            description = "https://shop-phinf.pstatic.net/20231116_59/1700105133758mQSba_JPEG/%EC%B9%A8%EC%B0%A9%ED%95%9C%ED%9B%84%EB%93%9C_%EC%83%81%EC%84%B8_1.jpg?type=w860",
-            canDeliverSafely = true,
-            canDeliverCommonly = false,
-            canPickUp = true,
-        )
-        val product3 = Product(
-            name = "니모를 찾아서 세트",
-            categoryId = category1.id,
-            price = BigDecimal.valueOf(80000L).setScale(2),
-            storeId = store1.id,
-            discountRate = 50,
-            discountPrice = BigDecimal(40000L).setScale(2),
-            wishCount = WishCount(100),
-            reviewCount = 50,
-            reviewTotalScore = 250,
-            thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
-            description = "https://store.img11.co.kr/68636870/cf26fe1a-98d5-486b-a79a-9dbfade97fb6_1690335864752.jpg",
-            canDeliverSafely = false,
-            canDeliverCommonly = true,
-            canPickUp = true,
-        )
-        productRepository.saveAll(listOf(product1, product2, product3))
-        saveProducts(store1.id, category1.id, member.id)
-
-        // productRecommendation
-        val productRecommendation1 = ProductRecommendation(productId = product3.id)
-        recommendationRepository.saveAll(listOf(productRecommendation1))
-
-        // productOption
-        productOptionRepository.saveAll(
-            listOf(
-                ProductOption(
-                    productId = product1.id,
-                    sex = MALE,
-                    additionalPrice = BigDecimal.ZERO
-                ),
-                ProductOption(
-                    productId = product2.id,
-                    sex = FEMALE,
-                    additionalPrice = BigDecimal.ZERO
-                ),
-                ProductOption(
-                    productId = product3.id,
-                    sex = HERMAPHRODITE,
-                    additionalPrice = BigDecimal.ZERO
-                ),
-            )
-        )
-
-        //productImage
-        productImageRepository.saveAll(
-            listOf(
-                ProductImage(
-                    productId = product1.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-                ),
-                ProductImage(
-                    productId = product1.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-                ),
-                ProductImage(
-                    productId = product1.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-                ),
-                ProductImage(
-                    productId = product1.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-                ),
-                ProductImage(
-                    productId = product1.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-                ),
-                ProductImage(
-                    productId = product2.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg"
-                ),
-                ProductImage(
-                    productId = product2.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg"
-                ),
-                ProductImage(
-                    productId = product2.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail2.jpeg"
-                ),
-                ProductImage(
-                    productId = product3.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg"
-                ),
-                ProductImage(
-                    productId = product3.id,
-                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg"
-                ),
-            )
-        )
-
-        // productInfo
-        productInfoRepository.saveAll(
-            listOf(
-                ProductInfo(
-                    productId = product1.id,
-                    categoryId = category1.id,
-                    optimalTemperature = OptimalTemperature(22, 25),
-                    difficultyLevel = EASY,
-                    optimalTankSize = TANK1,
-                    temperament = AGGRESSIVE
-                ),
-                ProductInfo(
-                    productId = product2.id,
-                    categoryId = category2.id,
-                    optimalTemperature = OptimalTemperature(22, 25),
-                    difficultyLevel = HARD,
-                    optimalTankSize = TANK3,
-                    temperament = PEACEFUL
-                ),
-                ProductInfo(
-                    productId = product3.id,
-                    categoryId = category2.id,
-                    optimalTemperature = OptimalTemperature(22, 25),
-                    difficultyLevel = NORMAL,
-                    optimalTankSize = TANK2,
-                    temperament = PEACEFUL
-                )
-            )
-        )
-
-        // productReview
-        val reviews = productReviewRepository.saveAll(
-            listOf(
-                ProductReview(
-                    productId = product1.id,
-                    memberId = member.id,
-                    content = "좋아요",
-                    score = 5,
-                    hasPhotos = true
-                ),
-                ProductReview(
-                    productId = product1.id,
-                    memberId = member.id,
-                    content = "조금 좋아요",
-                    score = 4,
-                    hasPhotos = false
-                ),
-                ProductReview(
-                    productId = product1.id,
-                    memberId = member.id,
-                    content = "약간 좋아요",
-                    score = 3,
-                    hasPhotos = false
-                ),
-            )
-        )
-        reviews.find { it.hasPhotos }?.let {
-            productReviewImageRepository.saveAll(
-                listOf(
-                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/1.jpeg", productReviewId = it.id),
-                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/2.jpeg", productReviewId = it.id),
-                    ProductReviewImage(imageUrl = "https://docs.petqua.co.kr/reviews/3.jpeg", productReviewId = it.id),
-                )
-            )
-        }
-    }
-
-    private fun saveProducts(storeId: Long, categoryId: Long, memberId: Long) {
+        // products
         val products = (1..100).map {
+            val categoryId = when {
+                (it % 2) == 0 -> category1.id
+                else -> category2.id
+            }
+            val canDeliverSafely = when {
+                (it % 4) == 0 -> true
+                else -> false
+            }
+            val canDeliverCommonly = when {
+                (it % 5) == 0 -> true
+                else -> false
+            }
+            val canPickUp = when {
+                (it % 2) == 0 -> true
+                else -> false
+            }
+            val reviewCount = (1..5).random()
+
             Product(
-                name = "니모를 찾아서 세트$it",
+                name = "상품$it",
                 categoryId = categoryId,
                 price = BigDecimal.valueOf(80000L).setScale(2),
-                storeId = storeId,
+                storeId = store.id,
                 discountRate = 50,
                 discountPrice = BigDecimal(40000L).setScale(2),
                 wishCount = WishCount(100),
-                reviewCount = 50,
-                reviewTotalScore = 250,
+                reviewCount = reviewCount,
+                reviewTotalScore = (1..reviewCount).sum(),
                 thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
-                description = "니모를 찾아서 주연 조연",
-                canDeliverSafely = true,
-                canDeliverCommonly = true,
-                canPickUp = true,
+                description = "https://www.goldmoonaqua.com/web/upload/NNEditor/20221226/copy-1672038777-guppy_EC958CEBB984EB85B8ED9280EBA088EB939C_02.png",
+                canDeliverSafely = canDeliverSafely,
+                canDeliverCommonly = canDeliverCommonly,
+                canPickUp = canPickUp,
             )
         }
         productRepository.saveAll(products)
 
+        // wishProducts
         val wishProducts = products.filter {
-            (it.id % 2).toInt() == 0
+            (it.id % 11).toInt() == 0
         }.map {
             WishProduct(
                 productId = it.id,
@@ -343,5 +192,88 @@ class DataInitializer(
             )
         }
         wishProductRepository.saveAll(wishProducts)
+
+        // productKeyword
+        val productKeywords = products.filter {
+            (it.id % 9).toInt() == 0
+        }.map {
+            ProductKeyword(
+                productId = it.id,
+                word = "상품"
+            )
+        }
+        productKeywordRepository.saveAll(productKeywords)
+
+        // productRecommendation
+        val productRecommendations = products.filter {
+            (it.id % 10).toInt() == 0
+        }.map {
+            ProductRecommendation(productId = it.id)
+        }
+        recommendationRepository.saveAll(productRecommendations)
+
+        // productOption
+        val productOptions = products.map {
+            val sex = when {
+                (it.id % 3).toInt() == 0 -> MALE
+                (it.id % 7).toInt() == 0 -> HERMAPHRODITE
+                else -> FEMALE
+            }
+            ProductOption(
+                productId = it.id,
+                sex = sex,
+                additionalPrice = BigDecimal.ZERO
+            )
+        }
+        productOptionRepository.saveAll(productOptions)
+
+        // productInfo
+        val productInfos = products.map {
+            ProductInfo(
+                productId = it.id,
+                categoryId = it.categoryId,
+                optimalTemperature = OptimalTemperature(22, 25),
+                difficultyLevel = NORMAL,
+                optimalTankSize = TANK2,
+                temperament = PEACEFUL
+            )
+        }
+        productInfoRepository.saveAll(productInfos)
+
+        // productImage
+        val productImages = products.map {
+            ProductImage(
+                productId = it.id,
+                imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg"
+            )
+        }
+        productImageRepository.saveAll(productImages)
+
+        // review
+        val productReviews = products.flatMap { product ->
+            val hasPhotos = (product.id % 2).toInt() == 0
+
+            (1..product.wishCount.value).map {
+                ProductReview(
+                    productId = product.id,
+                    memberId = memberId,
+                    content = "좋아요 ${product.name}",
+                    score = it,
+                    hasPhotos = hasPhotos
+                )
+            }
+        }
+        productReviewRepository.saveAll(productReviews)
+
+        // reviewImages
+        val productReviewImages = productReviews.filter {
+            it.hasPhotos
+        }.map {
+            ProductReviewImage(
+                imageUrl = "https://docs.petqua.co.kr/banners/announcement1.jpg",
+                productReviewId = it.id
+            )
+        }
+        productReviewImageRepository.saveAll(productReviewImages)
     }
 }

--- a/src/main/kotlin/com/petqua/domain/auth/LoginMemberOrGuest.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/LoginMemberOrGuest.kt
@@ -12,7 +12,7 @@ class LoginMemberOrGuest(
 ) {
 
     fun isMember(): Boolean {
-        return this != GUEST_INSTANCE;
+        return this != GUEST_INSTANCE
     }
 
     companion object {

--- a/src/main/kotlin/com/petqua/domain/auth/LoginMemberOrGuest.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/LoginMemberOrGuest.kt
@@ -2,9 +2,10 @@ package com.petqua.domain.auth
 
 import com.petqua.domain.auth.Authority.GUEST
 import com.petqua.domain.auth.token.AccessTokenClaims
+import io.swagger.v3.oas.annotations.Hidden
 import kotlin.Long.Companion.MIN_VALUE
 
-
+@Hidden
 class LoginMemberOrGuest(
     val memberId: Long,
     val authority: Authority,

--- a/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductController.kt
@@ -4,6 +4,7 @@ import com.petqua.application.product.ProductService
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.application.product.dto.ProductKeywordResponse
 import com.petqua.application.product.dto.ProductsResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.presentation.product.dto.ProductKeywordRequest
@@ -11,6 +12,7 @@ import com.petqua.presentation.product.dto.ProductReadRequest
 import com.petqua.presentation.product.dto.ProductSearchRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +29,7 @@ class ProductController(
 
     @Operation(summary = "상품 상세 조회 API", description = "상품의 상세 정보를 조회합니다")
     @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping("/{productId}")
     fun readById(
         @Auth loginMemberOrGuest: LoginMemberOrGuest,
@@ -38,6 +41,7 @@ class ProductController(
 
     @Operation(summary = "상품 조건 조회 API", description = "상품을 조건에 따라 조회합니다")
     @ApiResponse(responseCode = "200", description = "상품 조건 조회 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping
     fun readAll(
         @Auth loginMemberOrGuest: LoginMemberOrGuest,
@@ -49,6 +53,7 @@ class ProductController(
 
     @Operation(summary = "상품 검색 API", description = "검색으로 상품을 조회합니다")
     @ApiResponse(responseCode = "200", description = "상품 검색 조회 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping("/search")
     fun readBySearch(
         @Auth loginMemberOrGuest: LoginMemberOrGuest,

--- a/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
@@ -3,17 +3,23 @@ package com.petqua.presentation.product.category
 import com.petqua.application.product.category.CategoryService
 import com.petqua.application.product.dto.ProductsResponse
 import com.petqua.domain.product.category.SpeciesResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Category", description = "카테고리 관련 API 명세")
 @RequestMapping("/categories")
 @RestController
 class CategoryController(
     private val categoryService: CategoryService
 ) {
 
+    @Operation(summary = "카테고리 어종 조회 API", description = "어과 정보로 어종 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 어종 정보 조회 성공")
     @GetMapping
     fun readSpeciesBy(
         request: CategoryReadRequest,
@@ -23,6 +29,8 @@ class CategoryController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "카테고리 상품 조회 API", description = "어과에 속하는 상품 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 조회 성공")
     @GetMapping("/products")
     fun readProductsBy(
         request: CategoryProductReadRequest,

--- a/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
@@ -2,9 +2,11 @@ package com.petqua.presentation.product.category
 
 import com.petqua.application.product.category.CategoryService
 import com.petqua.application.product.dto.ProductsResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.product.category.SpeciesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,8 +31,9 @@ class CategoryController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(summary = "카테고리 상품 조회 API", description = "어과에 속하는 상품 목록을 조회합니다")
-    @ApiResponse(responseCode = "200", description = "카테고리 조회 성공")
+    @Operation(summary = "카테고리 조건 상품 조회 API", description = "카테고리에 속하는 상품 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 조건 상품 조회 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping("/products")
     fun readProductsBy(
         request: CategoryProductReadRequest,

--- a/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/category/CategoryController.kt
@@ -3,6 +3,8 @@ package com.petqua.presentation.product.category
 import com.petqua.application.product.category.CategoryService
 import com.petqua.application.product.dto.ProductsResponse
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
+import com.petqua.domain.auth.Auth
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.product.category.SpeciesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -36,9 +38,10 @@ class CategoryController(
     @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping("/products")
     fun readProductsBy(
+        @Auth loginMemberOrGuest: LoginMemberOrGuest,
         request: CategoryProductReadRequest,
     ): ResponseEntity<ProductsResponse> {
-        val query = request.toQuery()
+        val query = request.toQuery(loginMemberOrGuest)
         val response = categoryService.readProducts(query)
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/petqua/presentation/product/category/CategoryDto.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/category/CategoryDto.kt
@@ -4,6 +4,7 @@ import com.petqua.application.product.category.CategoryProductReadQuery
 import com.petqua.application.product.category.CategoryReadQuery
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.Sorter
 import io.swagger.v3.oas.annotations.media.Schema
@@ -63,7 +64,7 @@ data class CategoryProductReadRequest(
     val limit: Int = PAGING_LIMIT_CEILING,
 ) {
 
-    fun toQuery(): CategoryProductReadQuery {
+    fun toQuery(loginMemberOrGuest: LoginMemberOrGuest): CategoryProductReadQuery {
         return CategoryProductReadQuery(
             family = family,
             species = species,
@@ -71,6 +72,7 @@ data class CategoryProductReadRequest(
             sorter = sorter,
             lastViewedId = lastViewedId,
             limit = limit,
+            loginMemberOrGuest = loginMemberOrGuest,
         )
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductDtos.kt
@@ -5,8 +5,8 @@ import com.petqua.application.product.dto.ProductReadQuery
 import com.petqua.application.product.dto.ProductSearchQuery
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
-import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.auth.LoginMemberOrGuest
+import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import io.swagger.v3.oas.annotations.media.Schema
@@ -98,8 +98,8 @@ data class ProductSearchRequest(
 
 data class ProductKeywordRequest(
     @Schema(
-        description = "마지막으로 조회한 상품의 Id",
-        example = "1"
+        description = "검색어",
+        example = "상"
     )
     val word: String,
 

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerSteps.kt
@@ -5,12 +5,12 @@ import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.ProductSourceType.NONE
 import com.petqua.domain.product.Sorter
+import com.petqua.test.authorize
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.restassured.response.Response
-import io.restassured.specification.RequestSpecification
 
 fun requestReadProductById(
     productId: Long,
@@ -27,10 +27,6 @@ fun requestReadProductById(
     } Extract {
         response()
     }
-}
-
-private fun RequestSpecification.authorize(accessToken: String?): RequestSpecification? {
-    return accessToken?.let { auth().preemptive().oauth2(it) }
 }
 
 fun requestReadAllProducts(

--- a/src/test/kotlin/com/petqua/presentation/product/category/CategoryControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/category/CategoryControllerSteps.kt
@@ -2,6 +2,7 @@ package com.petqua.presentation.product.category
 
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.Sorter
+import com.petqua.test.authorize
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -34,6 +35,7 @@ fun requestReadProducts(
     sorter: Sorter? = null,
     lastViewedId: Long? = null,
     limit: Int? = null,
+    accessToken: String? = null,
 ): Response {
     val paramMap = mutableMapOf<String, Any?>().apply {
         put("family", family)
@@ -46,6 +48,7 @@ fun requestReadProducts(
 
     return Given {
         log().all()
+        authorize(accessToken)
         params(paramMap)
     } When {
         get("/categories/products")

--- a/src/test/kotlin/com/petqua/test/TestUtil.kt
+++ b/src/test/kotlin/com/petqua/test/TestUtil.kt
@@ -1,0 +1,7 @@
+package com.petqua.test
+
+import io.restassured.specification.RequestSpecification
+
+fun RequestSpecification.authorize(accessToken: String?): RequestSpecification? {
+    return accessToken?.let { auth().preemptive().oauth2(it) }
+}


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #78 

### 📁 작업 설명

- 상품 상세 조회, 카테고리 조건 상품 조회 API 에 대한 Swagger 설정이 누락되어 추가했습니다.
- 카테고리 조건 상품 조회 API는 LoginMemberOrGuest 도 추가했습니다.
- Swagger 테스트하는 김에 더미데이터 생성 로직을 변경했습니다. 나름 데이터 정합성을 맞추려고 노력했습니다!