### PR TITLE
feat: 회원/비회에 따른 상품 후기 조회시 추천 여부 포함하여 응답

### DIFF
--- a/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductReviewDtos.kt
@@ -4,6 +4,7 @@ import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.product.dto.ProductReviewReadCondition
 import com.petqua.domain.product.dto.ProductReviewWithMemberResponse
 import com.petqua.domain.product.review.ProductReviewSorter
@@ -14,7 +15,7 @@ import java.time.LocalDateTime
 
 data class ProductReviewReadQuery(
     val productId: Long,
-    val memberId: Long?,
+    val loginMemberOrGuest: LoginMemberOrGuest,
     val sorter: ProductReviewSorter = REVIEW_DATE_DESC,
     val score: Int? = null,
     val photoOnly: Boolean = false,

--- a/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
+++ b/src/main/kotlin/com/petqua/application/product/review/ProductReviewService.kt
@@ -40,7 +40,16 @@ class ProductReviewService(
         val responses = reviewsByCondition.map {
             ProductReviewResponse(it, imagesByReview[it.id] ?: emptyList())
         }
-        // TODO: 추천 여부 반영
+
+        if (query.loginMemberOrGuest.isMember()) {
+            val recommendations = productReviewRecommendationRepository.findAllByMemberIdAndProductReviewIdIn(
+                query.loginMemberOrGuest.memberId,
+                responses.map { it.id },
+            ).map { it.productReviewId }
+
+            val recommendationMarkedResponses = responses.map { it.copy(recommended = recommendations.contains(it.id)) }
+            return ProductReviewsResponse.of(recommendationMarkedResponses, query.limit)
+        }
         return ProductReviewsResponse.of(responses, query.limit)
     }
 

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewRecommendationRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewRecommendationRepository.kt
@@ -5,4 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ProductReviewRecommendationRepository : JpaRepository<ProductReviewRecommendation, Long> {
 
     fun findByProductReviewIdAndMemberId(productReviewId: Long, memberId: Long): ProductReviewRecommendation?
+
+    fun findAllByMemberIdAndProductReviewIdIn(
+        memberId: Long,
+        productReviewIds: List<Long>
+    ): Set<ProductReviewRecommendation>
 }

--- a/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/ProductReviewController.kt
@@ -6,6 +6,7 @@ import com.petqua.application.product.review.ProductReviewService
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.presentation.product.dto.ReadAllProductReviewsRequest
 import com.petqua.presentation.product.dto.UpdateReviewRecommendationRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -27,16 +28,17 @@ class ProductReviewController(
 
     @Operation(summary = "상품 후기 조건 조회 API", description = "상품의 후기를 조건에 따라 조회합니다")
     @ApiResponse(responseCode = "200", description = "상품 후기 조건 조회 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping("/products/{productId}/reviews")
     fun readAll(
-//        @Auth loginMember: LoginMember, TODO: 비회원도 조회 가능 (회원인 경우 추천 여부 반영)
+        @Auth loginMemberOrGuest: LoginMemberOrGuest,
         request: ReadAllProductReviewsRequest,
         @PathVariable productId: Long,
     ): ResponseEntity<ProductReviewsResponse> {
         val responses = productReviewService.readAll(
             request.toCommand(
                 productId = productId,
-                null, // loginMember.memberId
+                loginMemberOrGuest = loginMemberOrGuest,
             )
         )
         return ResponseEntity.ok(responses)

--- a/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/product/dto/ProductReviewDtos.kt
@@ -3,6 +3,7 @@ package com.petqua.presentation.product.dto
 import com.petqua.application.product.dto.ProductReviewReadQuery
 import com.petqua.application.product.dto.UpdateReviewRecommendationCommand
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.product.review.ProductReviewSorter
 import com.petqua.domain.product.review.ProductReviewSorter.REVIEW_DATE_DESC
 import io.swagger.v3.oas.annotations.media.Schema
@@ -40,10 +41,10 @@ data class ReadAllProductReviewsRequest(
     )
     val limit: Int = PAGING_LIMIT_CEILING,
 ) {
-    fun toCommand(productId: Long, memberId: Long?): ProductReviewReadQuery {
+    fun toCommand(productId: Long, loginMemberOrGuest: LoginMemberOrGuest): ProductReviewReadQuery {
         return ProductReviewReadQuery(
             productId = productId,
-            memberId = memberId,
+            loginMemberOrGuest = loginMemberOrGuest,
             sorter = sorter,
             score = score,
             photoOnly = photoOnly,


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #85 

### 📁 작업 설명
- 설명
#51 에서 TODO로 남겨두었던 상품 후기 추천 여부 반영 로직을 추가하였습니다.
찬민님이 (#76)에서 만드셨던 `LoginOrGuest`를 활용하였습니다.
