### PR TITLE
fix: 초기 데이터 리뷰 별점 수정

### DIFF
--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -39,12 +39,12 @@ import com.petqua.domain.recommendation.ProductRecommendation
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
+import java.math.BigDecimal
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Component
 @Profile("local", "prod")
@@ -258,7 +258,7 @@ class DataInitializer(
                     productId = product.id,
                     memberId = memberId,
                     content = "좋아요 ${product.name}",
-                    score = it,
+                    score = it % 5 + 1,
                     hasPhotos = hasPhotos
                 )
             }

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -35,6 +35,7 @@ import com.petqua.domain.product.review.ProductReview
 import com.petqua.domain.product.review.ProductReviewImage
 import com.petqua.domain.product.review.ProductReviewImageRepository
 import com.petqua.domain.product.review.ProductReviewRepository
+import com.petqua.domain.product.review.ProductReviewScore
 import com.petqua.domain.recommendation.ProductRecommendation
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
@@ -258,7 +259,7 @@ class DataInitializer(
                     productId = product.id,
                     memberId = memberId,
                     content = "좋아요 ${product.name}",
-                    score = it % 5 + 1,
+                    score = ProductReviewScore(it % 5 + 1),
                     hasPhotos = hasPhotos
                 )
             }

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductReviewDtos.kt
@@ -31,7 +31,7 @@ data class ProductReviewWithMemberResponse(
     constructor(productReview: ProductReview, reviewer: Member) : this(
         id = productReview.id,
         productId = productReview.productId,
-        score = productReview.score,
+        score = productReview.score.value,
         content = productReview.content,
         createdAt = productReview.createdAt,
         hasPhotos = productReview.hasPhotos,

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReview.kt
@@ -1,7 +1,9 @@
 package com.petqua.domain.product.review
 
 import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.AttributeOverride
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -21,8 +23,9 @@ class ProductReview(
     @Column(nullable = false)
     val memberId: Long,
 
-    @Column(nullable = false)
-    val score: Int,
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "score"))
+    val score: ProductReviewScore,
 
     @Column(nullable = false)
     var recommendCount: Int = 0,

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewCustomRepositoryImpl.kt
@@ -52,7 +52,7 @@ class ProductReviewCustomRepositoryImpl(
     override fun findReviewScoresWithCount(productId: Long): List<ProductReviewScoreWithCount> {
         val query = jpql {
             selectNew<ProductReviewScoreWithCount>(
-                path(ProductReview::score),
+                path(ProductReview::score)(ProductReviewScore::value),
                 count(path(ProductReview::score)),
             ).from(
                 entity(ProductReview::class),

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewDynamicJpqlGenerator.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewDynamicJpqlGenerator.kt
@@ -22,7 +22,7 @@ class ProductReviewDynamicJpqlGenerator : Jpql() {
     }
 
     fun Jpql.productReviewScoreEq(score: Int?): Predicate? {
-        return score?.let { path(ProductReview::score).eq(it) }
+        return score?.let { path(ProductReview::score).eq(ProductReviewScore(it)) }
     }
 
     fun Jpql.sortBy(sorter: ProductReviewSorter): SortNullsStep {

--- a/src/main/kotlin/com/petqua/domain/product/review/ProductReviewScore.kt
+++ b/src/main/kotlin/com/petqua/domain/product/review/ProductReviewScore.kt
@@ -1,0 +1,29 @@
+package com.petqua.domain.product.review
+
+import com.petqua.common.util.throwExceptionWhen
+import com.petqua.exception.product.review.ProductReviewException
+import com.petqua.exception.product.review.ProductReviewExceptionType.REVIEW_SCORE_OUT_OF_RANGE
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class ProductReviewScore(
+    val value: Int,
+) {
+
+    init {
+        throwExceptionWhen(value !in 1..5) { ProductReviewException(REVIEW_SCORE_OUT_OF_RANGE) }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ProductReviewScore
+
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value
+    }
+}

--- a/src/main/kotlin/com/petqua/exception/product/review/ProductReviewExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/product/review/ProductReviewExceptionType.kt
@@ -11,6 +11,7 @@ enum class ProductReviewExceptionType(
 ) : BaseExceptionType {
 
     NOT_FOUND_PRODUCT_REVIEW(NOT_FOUND, "PR01", "존재하지 않는 리뷰입니다."),
+    REVIEW_SCORE_OUT_OF_RANGE(NOT_FOUND, "PR02", "리뷰 별점은 1점부터 5점까지만 가능합니다.")
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/test/kotlin/com/petqua/domain/product/review/ProductReviewScoreTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/review/ProductReviewScoreTest.kt
@@ -1,0 +1,20 @@
+package com.petqua.domain.product.review
+
+import com.petqua.exception.product.review.ProductReviewException
+import com.petqua.exception.product.review.ProductReviewExceptionType
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+
+class ProductReviewScoreTest : StringSpec({
+
+    "ProductReviewScore 생성시 별점이 1점부터 5점 사이가 아니면 예외가 발생한다." {
+        listOf(0, 6, 10, -1, 100)
+            .forAll { score ->
+                shouldThrow<ProductReviewException> {
+                    ProductReviewScore(value = score)
+                }.exceptionType() shouldBe ProductReviewExceptionType.REVIEW_SCORE_OUT_OF_RANGE
+            }
+    }
+})

--- a/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductReviewFixtures.kt
@@ -2,6 +2,7 @@ package com.petqua.test.fixture
 
 import com.petqua.domain.product.review.ProductReview
 import com.petqua.domain.product.review.ProductReviewImage
+import com.petqua.domain.product.review.ProductReviewScore
 
 fun productReview(
     id: Long = 0L,
@@ -17,7 +18,7 @@ fun productReview(
         content = content,
         productId = productId,
         memberId = reviewerId,
-        score = score,
+        score = ProductReviewScore(score),
         recommendCount = recommendCount,
         hasPhotos = hasPhotos,
     )


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #90 

### 📁 작업 설명
- 상품 후기의 초기 데이터 별점이 1-5 사이 값을 가지도록 수정
- 상품 별점에 대한 값 객체 적용

