### PR TITLE
refactor: 상품 상세 조회 api 응답 필드 수정

### DIFF
--- a/src/main/kotlin/com/petqua/application/product/ProductService.kt
+++ b/src/main/kotlin/com/petqua/application/product/ProductService.kt
@@ -12,7 +12,7 @@ import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.detail.image.ImageType
 import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
-import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ImageType.SAMPLE
 import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.exception.product.ProductException
@@ -43,7 +43,7 @@ class ProductService(
 
         return ProductDetailResponse(
             productWithInfoResponse = productWithInfo,
-            imageUrls = imagesByType[EXAMPLE] ?: emptyList(),
+            imageUrls = imagesByType[SAMPLE] ?: emptyList(),
             descriptionImageUrls = imagesByType[DESCRIPTION] ?: emptyList(),
             isWished = isWished
         )

--- a/src/main/kotlin/com/petqua/application/product/ProductService.kt
+++ b/src/main/kotlin/com/petqua/application/product/ProductService.kt
@@ -10,7 +10,10 @@ import com.petqua.domain.auth.LoginMemberOrGuest
 import com.petqua.domain.keyword.ProductKeywordRepository
 import com.petqua.domain.product.ProductRepository
 import com.petqua.domain.product.WishProductRepository
-import com.petqua.domain.product.detail.ProductImageRepository
+import com.petqua.domain.product.detail.image.ImageType
+import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
+import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
@@ -31,13 +34,24 @@ class ProductService(
         val productWithInfo = productRepository.findProductWithInfoByIdOrThrow(productId) {
             ProductException(NOT_FOUND_PRODUCT)
         }
-        val imageUrls = productImageRepository.findProductImagesByProductId(productId).map { it.imageUrl }
+
+        val imagesByType = getProductImagesGroupedByType(productId)
         val isWished = loginMemberOrGuest.isMember() && wishProductRepository.existsByProductIdAndMemberId(
             productId = productId,
             memberId = loginMemberOrGuest.memberId
         )
 
-        return ProductDetailResponse(productWithInfo, imageUrls, isWished)
+        return ProductDetailResponse(
+            productWithInfoResponse = productWithInfo,
+            imageUrls = imagesByType[EXAMPLE] ?: emptyList(),
+            descriptionImageUrls = imagesByType[DESCRIPTION] ?: emptyList(),
+            isWished = isWished
+        )
+    }
+
+    private fun getProductImagesGroupedByType(productId: Long): Map<ImageType, List<String>> {
+        return productImageRepository.findProductImagesByProductId(productId).groupBy { it.imageType }
+            .mapValues { it.value.map { productImage -> productImage.imageUrl } }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -84,22 +84,28 @@ data class ProductDetailResponse(
     val reviewAverageScore: Double,
 
     @Schema(
-        description = "상품 썸네일 이미지",
-        example = "https://docs.petqua.co.kr/products/thumbnails/thumbnail1.jpeg"
-    )
-    val thumbnailUrl: String,
-
-    @Schema(
         description = "상품 이미지 목록",
         example = "[image1.jpeg, image2.jpeg]"
     )
     val imageUrls: List<String>,
 
     @Schema(
-        description = "상품 상세 설명",
-        example = "귀엽습니다"
+        description = "상품 상세 설명 제목",
+        example = "물생활 핵 인싸어, 레드 브론즈 구피"
     )
-    val description: String,
+    val descriptionTitle: String,
+
+    @Schema(
+        description = "상품 상세 설명 내용",
+        example = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+    )
+    val descriptionContent: String,
+
+    @Schema(
+        description = "상품 상세 이미지",
+        example = "[image1.jpeg, image2.jpeg]"
+    )
+    val descriptionImageUrls: List<String>,
 
     @Schema(
         description = "안전 배송 가능 여부",
@@ -164,6 +170,7 @@ data class ProductDetailResponse(
     constructor(
         productWithInfoResponse: ProductWithInfoResponse,
         imageUrls: List<String>,
+        descriptionImageUrls: List<String>,
         isWished: Boolean,
     ) : this(
         id = productWithInfoResponse.id,
@@ -177,9 +184,10 @@ data class ProductDetailResponse(
         wishCount = productWithInfoResponse.wishCount,
         reviewCount = productWithInfoResponse.reviewCount,
         reviewAverageScore = productWithInfoResponse.reviewAverageScore,
-        thumbnailUrl = productWithInfoResponse.thumbnailUrl,
-        description = productWithInfoResponse.description,
         imageUrls = imageUrls,
+        descriptionTitle = productWithInfoResponse.descriptionTitle,
+        descriptionContent = productWithInfoResponse.descriptionContent,
+        descriptionImageUrls = descriptionImageUrls,
         canDeliverSafely = productWithInfoResponse.canDeliverSafely,
         canDeliverCommonly = productWithInfoResponse.canDeliverCommonly,
         canPickUp = productWithInfoResponse.canPickUp,

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -23,7 +23,7 @@ import com.petqua.domain.product.detail.description.ProductDescriptionContent
 import com.petqua.domain.product.detail.description.ProductDescriptionRepository
 import com.petqua.domain.product.detail.description.ProductDescriptionTitle
 import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
-import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ImageType.SAMPLE
 import com.petqua.domain.product.detail.image.ProductImage
 import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.detail.info.DifficultyLevel.NORMAL
@@ -264,7 +264,7 @@ class DataInitializer(
                 ProductImage(
                     productId = product.id,
                     imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
-                    imageType = EXAMPLE
+                    imageType = SAMPLE
                 )
             }
         }

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -202,7 +202,9 @@ class DataInitializer(
         wishProductRepository.saveAll(wishProducts)
 
         // productDescription
-        val productDescriptions = products.map {
+        val productDescriptions = products.filter {
+            (it.id % 4).toInt() != 0
+        }.map {
             ProductDescription(
                 productId = it.id,
                 title = ProductDescriptionTitle("물생활 핵 인싸어, ${it.name}"),

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -18,14 +18,20 @@ import com.petqua.domain.product.category.Category
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.category.Family
 import com.petqua.domain.product.category.Species
-import com.petqua.domain.product.detail.DifficultyLevel.NORMAL
-import com.petqua.domain.product.detail.OptimalTankSize.TANK2
-import com.petqua.domain.product.detail.OptimalTemperature
-import com.petqua.domain.product.detail.ProductImage
-import com.petqua.domain.product.detail.ProductImageRepository
-import com.petqua.domain.product.detail.ProductInfo
-import com.petqua.domain.product.detail.ProductInfoRepository
-import com.petqua.domain.product.detail.Temperament.PEACEFUL
+import com.petqua.domain.product.detail.description.ProductDescription
+import com.petqua.domain.product.detail.description.ProductDescriptionContent
+import com.petqua.domain.product.detail.description.ProductDescriptionRepository
+import com.petqua.domain.product.detail.description.ProductDescriptionTitle
+import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
+import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ProductImage
+import com.petqua.domain.product.detail.image.ProductImageRepository
+import com.petqua.domain.product.detail.info.DifficultyLevel.NORMAL
+import com.petqua.domain.product.detail.info.OptimalTankSize.TANK2
+import com.petqua.domain.product.detail.info.OptimalTemperature
+import com.petqua.domain.product.detail.info.ProductInfo
+import com.petqua.domain.product.detail.info.ProductInfoRepository
+import com.petqua.domain.product.detail.info.Temperament.PEACEFUL
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.product.option.Sex.FEMALE
@@ -46,6 +52,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
 
 @Component
 @Profile("local", "prod")
@@ -64,6 +71,7 @@ class DataInitializer(
     private val productOptionRepository: ProductOptionRepository,
     private val wishProductRepository: WishProductRepository,
     private val productKeywordRepository: ProductKeywordRepository,
+    private val productDescriptionRepository: ProductDescriptionRepository,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
@@ -175,7 +183,6 @@ class DataInitializer(
                 reviewCount = reviewCount,
                 reviewTotalScore = (1..reviewCount).sum(),
                 thumbnailUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
-                description = "https://www.goldmoonaqua.com/web/upload/NNEditor/20221226/copy-1672038777-guppy_EC958CEBB984EB85B8ED9280EBA088EB939C_02.png",
                 canDeliverSafely = canDeliverSafely,
                 canDeliverCommonly = canDeliverCommonly,
                 canPickUp = canPickUp,
@@ -193,6 +200,16 @@ class DataInitializer(
             )
         }
         wishProductRepository.saveAll(wishProducts)
+
+        // productDescription
+        val productDescriptions = products.map {
+            ProductDescription(
+                productId = it.id,
+                title = ProductDescriptionTitle("물생활 핵 인싸어, ${it.name}"),
+                content = ProductDescriptionContent("지느러미가 아름다운 ${it.name}입니다")
+            )
+        }
+        productDescriptionRepository.saveAll(productDescriptions)
 
         // productKeyword
         val productKeywords = products.filter {
@@ -242,13 +259,26 @@ class DataInitializer(
         productInfoRepository.saveAll(productInfos)
 
         // productImage
-        val productImages = products.map {
-            ProductImage(
-                productId = it.id,
-                imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg"
-            )
+        val productImages = products.flatMap { product ->
+            List(Random.nextInt(1, 6)) {
+                ProductImage(
+                    productId = product.id,
+                    imageUrl = "https://docs.petqua.co.kr/products/thumbnails/thumbnail3.jpeg",
+                    imageType = EXAMPLE
+                )
+            }
         }
         productImageRepository.saveAll(productImages)
+
+        // productDescriptionImage
+        val productDescriptionImages = products.map {
+            ProductImage(
+                productId = it.id,
+                imageUrl = "https://www.goldmoonaqua.com/web/upload/NNEditor/20221226/copy-1672038777-guppy_EC958CEBB984EB85B8ED9280EBA088EB939C_02.png",
+                imageType = DESCRIPTION
+            )
+        }
+        productImageRepository.saveAll(productDescriptionImages)
 
         // review
         val productReviews = products.flatMap { product ->

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -172,6 +172,39 @@ class DataInitializer(
             }
             val reviewCount = (1..5).random()
 
+            val sex = when {
+                (it % 3) == 0 -> MALE
+                (it % 7) == 0 -> FEMALE
+                else -> HERMAPHRODITE
+            }
+            val productOption = productOptionRepository.save(
+                ProductOption(
+                    sex = sex,
+                    additionalPrice = BigDecimal.ZERO
+                )
+            )
+
+            val productInfo = productInfoRepository.save(
+                ProductInfo(
+                    categoryId = categoryId,
+                    optimalTemperature = OptimalTemperature(22, 25),
+                    difficultyLevel = NORMAL,
+                    optimalTankSize = TANK2,
+                    temperament = PEACEFUL
+                )
+            )
+
+            val productDescriptionId = when {
+                (it % 4) != 0 -> productDescriptionRepository.save(
+                    ProductDescription(
+                        title = ProductDescriptionTitle("물생활 핵 인싸어, 상품$it"),
+                        content = ProductDescriptionContent("지느러미가 아름다운 상품$it 입니다")
+                    )
+                ).id
+
+                else -> null
+            }
+
             Product(
                 name = "상품$it",
                 categoryId = categoryId,
@@ -186,6 +219,9 @@ class DataInitializer(
                 canDeliverSafely = canDeliverSafely,
                 canDeliverCommonly = canDeliverCommonly,
                 canPickUp = canPickUp,
+                productOptionId = productOption.id,
+                productDescriptionId = productDescriptionId,
+                productInfoId = productInfo.id,
             )
         }
         productRepository.saveAll(products)
@@ -200,18 +236,6 @@ class DataInitializer(
             )
         }
         wishProductRepository.saveAll(wishProducts)
-
-        // productDescription
-        val productDescriptions = products.filter {
-            (it.id % 4).toInt() != 0
-        }.map {
-            ProductDescription(
-                productId = it.id,
-                title = ProductDescriptionTitle("물생활 핵 인싸어, ${it.name}"),
-                content = ProductDescriptionContent("지느러미가 아름다운 ${it.name}입니다")
-            )
-        }
-        productDescriptionRepository.saveAll(productDescriptions)
 
         // productKeyword
         val productKeywords = products.filter {
@@ -231,34 +255,6 @@ class DataInitializer(
             ProductRecommendation(productId = it.id)
         }
         recommendationRepository.saveAll(productRecommendations)
-
-        // productOption
-        val productOptions = products.map {
-            val sex = when {
-                (it.id % 3).toInt() == 0 -> MALE
-                (it.id % 7).toInt() == 0 -> HERMAPHRODITE
-                else -> FEMALE
-            }
-            ProductOption(
-                productId = it.id,
-                sex = sex,
-                additionalPrice = BigDecimal.ZERO
-            )
-        }
-        productOptionRepository.saveAll(productOptions)
-
-        // productInfo
-        val productInfos = products.map {
-            ProductInfo(
-                productId = it.id,
-                categoryId = it.categoryId,
-                optimalTemperature = OptimalTemperature(22, 25),
-                difficultyLevel = NORMAL,
-                optimalTankSize = TANK2,
-                temperament = PEACEFUL
-            )
-        }
-        productInfoRepository.saveAll(productInfos)
 
         // productImage
         val productImages = products.flatMap { product ->

--- a/src/main/kotlin/com/petqua/domain/product/Product.kt
+++ b/src/main/kotlin/com/petqua/domain/product/Product.kt
@@ -14,9 +14,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import java.math.BigDecimal
 
-private const val SCALE = 1
-private const val ZERO = 0
-
 @Entity
 class Product(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,9 +51,6 @@ class Product(
     val thumbnailUrl: String,
 
     @Column(nullable = false)
-    val description: String,
-
-    @Column(nullable = false)
     var isDeleted: Boolean = false,
 
     @Column(nullable = false)
@@ -88,6 +82,6 @@ class Product(
     }
 
     override fun toString(): String {
-        return "Product(id=$id, name='$name', categoryId=$categoryId, price=$price, storeId=$storeId, discountRate=$discountRate, discountPrice=$discountPrice, wishCount=$wishCount, reviewCount=$reviewCount, reviewTotalScore=$reviewTotalScore, thumbnailUrl='$thumbnailUrl', description='$description', isDeleted=$isDeleted, canDeliverSafely=$canDeliverSafely, canDeliverCommonly=$canDeliverCommonly, canPickUp=$canPickUp)"
+        return "Product(id=$id, name='$name', categoryId=$categoryId, price=$price, storeId=$storeId, discountRate=$discountRate, discountPrice=$discountPrice, wishCount=$wishCount, reviewCount=$reviewCount, reviewTotalScore=$reviewTotalScore, thumbnailUrl='$thumbnailUrl', isDeleted=$isDeleted, canDeliverSafely=$canDeliverSafely, canDeliverCommonly=$canDeliverCommonly, canPickUp=$canPickUp)"
     }
 }

--- a/src/main/kotlin/com/petqua/domain/product/Product.kt
+++ b/src/main/kotlin/com/petqua/domain/product/Product.kt
@@ -23,13 +23,13 @@ class Product(
     val name: String,
 
     @Column(nullable = false)
-    val categoryId: Long = 0,
+    val categoryId: Long,
 
     @Column(nullable = false)
     val price: BigDecimal,
 
     @Column(nullable = false)
-    val storeId: Long = 0,
+    val storeId: Long,
 
     @Column(nullable = false)
     val discountRate: Int = 0,

--- a/src/main/kotlin/com/petqua/domain/product/Product.kt
+++ b/src/main/kotlin/com/petqua/domain/product/Product.kt
@@ -61,6 +61,14 @@ class Product(
 
     @Column(nullable = false)
     val canPickUp: Boolean,
+
+    @Column(nullable = false)
+    val productOptionId: Long,
+
+    val productDescriptionId: Long?,
+
+    @Column(nullable = false)
+    val productInfoId: Long,
 ) : BaseEntity(), SoftDeleteEntity {
 
     fun averageReviewScore(): Double {

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepository.kt
@@ -3,8 +3,8 @@ package com.petqua.domain.product
 import com.petqua.common.domain.dto.CursorBasedPaging
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
-import com.petqua.domain.product.dto.ProductWithInfoResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
+import com.petqua.domain.product.dto.ProductWithInfoResponse
 
 interface ProductCustomRepository {
 

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -10,7 +10,8 @@ import com.petqua.common.util.createSingleQueryOrThrow
 import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.category.Category
-import com.petqua.domain.product.detail.ProductInfo
+import com.petqua.domain.product.detail.description.ProductDescription
+import com.petqua.domain.product.detail.info.ProductInfo
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
@@ -37,12 +38,14 @@ class ProductCustomRepositoryImpl(
             selectNew<ProductWithInfoResponse>(
                 entity(Product::class),
                 path(Store::name),
+                entity(ProductDescription::class),
                 entity(ProductInfo::class),
                 entity(Category::class),
                 entity(ProductOption::class),
             ).from(
                 entity(Product::class),
                 join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
+                join(ProductDescription::class).on(path(Product::id).eq(path(ProductDescription::productId))),
                 join(ProductInfo::class).on(path(Product::id).eq(path(ProductInfo::productId))),
                 join(Category::class).on(path(Product::categoryId).eq(path(Category::id))),
                 join(ProductOption::class).on(path(Product::id).eq(path(ProductOption::productId)))

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -11,7 +11,10 @@ import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.category.Category
 import com.petqua.domain.product.detail.description.ProductDescription
+import com.petqua.domain.product.detail.description.ProductDescriptionContent
+import com.petqua.domain.product.detail.description.ProductDescriptionTitle
 import com.petqua.domain.product.detail.info.ProductInfo
+import com.petqua.domain.product.dto.ProductDescriptionResponse
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
@@ -22,6 +25,7 @@ import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
 
 private const val ESCAPE_LETTER = '\\'
+private const val EMPTY_VALUE = ""
 
 @Repository
 class ProductCustomRepositoryImpl(
@@ -38,14 +42,18 @@ class ProductCustomRepositoryImpl(
             selectNew<ProductWithInfoResponse>(
                 entity(Product::class),
                 path(Store::name),
-                entity(ProductDescription::class),
+                new(
+                    ProductDescriptionResponse::class,
+                    coalesce(path(ProductDescription::title)(ProductDescriptionTitle::value), EMPTY_VALUE),
+                    coalesce(path(ProductDescription::content)(ProductDescriptionContent::value), EMPTY_VALUE)
+                ),
                 entity(ProductInfo::class),
                 entity(Category::class),
                 entity(ProductOption::class),
             ).from(
                 entity(Product::class),
                 join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
-                join(ProductDescription::class).on(path(Product::id).eq(path(ProductDescription::productId))),
+                leftJoin(ProductDescription::class).on(path(Product::id).eq(path(ProductDescription::productId))),
                 join(ProductInfo::class).on(path(Product::id).eq(path(ProductInfo::productId))),
                 join(Category::class).on(path(Product::categoryId).eq(path(Category::id))),
                 join(ProductOption::class).on(path(Product::id).eq(path(ProductOption::productId)))

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -53,10 +53,10 @@ class ProductCustomRepositoryImpl(
             ).from(
                 entity(Product::class),
                 join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
-                leftJoin(ProductDescription::class).on(path(Product::id).eq(path(ProductDescription::productId))),
-                join(ProductInfo::class).on(path(Product::id).eq(path(ProductInfo::productId))),
+                leftJoin(ProductDescription::class).on(path(Product::productDescriptionId).eq(path(ProductDescription::id))),
+                join(ProductInfo::class).on(path(Product::productInfoId).eq(path(ProductInfo::id))),
                 join(Category::class).on(path(Product::categoryId).eq(path(Category::id))),
-                join(ProductOption::class).on(path(Product::id).eq(path(ProductOption::productId)))
+                join(ProductOption::class).on(path(Product::productOptionId).eq(path(ProductOption::id)))
             ).whereAnd(
                 path(Product::id).eq(id),
                 active(),

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
@@ -11,15 +11,15 @@ import jakarta.persistence.Id
 @Entity
 class ProductDescription(
     @Id @GeneratedValue(strategy = IDENTITY)
-    val id: Long,
+    val id: Long = 0,
 
     @Column(nullable = false)
     val productId: Long,
 
     @Embedded
-    val productDescriptionTitle: ProductDescriptionTitle,
+    val title: ProductDescriptionTitle,
 
     @Embedded
-    val productDescriptionContent: ProductDescriptionContent,
+    val content: ProductDescriptionContent,
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
@@ -1,0 +1,25 @@
+package com.petqua.domain.product.detail.description
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType.IDENTITY
+import jakarta.persistence.Id
+
+@Entity
+class ProductDescription(
+    @Id @GeneratedValue(strategy = IDENTITY)
+    val id: Long,
+
+    @Column(nullable = false)
+    val productId: Long,
+
+    @Embedded
+    val productDescriptionTitle: ProductDescriptionTitle,
+
+    @Embedded
+    val productDescriptionContent: ProductDescriptionContent,
+) : BaseEntity() {
+}

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescription.kt
@@ -1,7 +1,6 @@
 package com.petqua.domain.product.detail.description
 
 import com.petqua.common.domain.BaseEntity
-import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -12,9 +11,6 @@ import jakarta.persistence.Id
 class ProductDescription(
     @Id @GeneratedValue(strategy = IDENTITY)
     val id: Long = 0,
-
-    @Column(nullable = false)
-    val productId: Long,
 
     @Embedded
     val title: ProductDescriptionTitle,

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionContent.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionContent.kt
@@ -1,0 +1,8 @@
+package com.petqua.domain.product.detail.description
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class ProductDescriptionContent(
+    val content: String,
+)

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionContent.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionContent.kt
@@ -1,8 +1,10 @@
 package com.petqua.domain.product.detail.description
 
+import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
 data class ProductDescriptionContent(
-    val content: String,
+    @Column(nullable = false, name = "content")
+    val value: String,
 )

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionRepository.kt
@@ -1,0 +1,5 @@
+package com.petqua.domain.product.detail.description
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductDescriptionRepository : JpaRepository<ProductDescription, Long>

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionTitle.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionTitle.kt
@@ -1,0 +1,10 @@
+package com.petqua.domain.product.detail.description
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class ProductDescriptionTitle(
+    @Column(nullable = false)
+    val title: String,
+)

--- a/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionTitle.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/description/ProductDescriptionTitle.kt
@@ -5,6 +5,6 @@ import jakarta.persistence.Embeddable
 
 @Embeddable
 data class ProductDescriptionTitle(
-    @Column(nullable = false)
-    val title: String,
+    @Column(nullable = false, name = "title")
+    val value: String,
 )

--- a/src/main/kotlin/com/petqua/domain/product/detail/image/ImageType.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/image/ImageType.kt
@@ -1,0 +1,10 @@
+package com.petqua.domain.product.detail.image
+
+enum class ImageType(
+    val description: String,
+) {
+
+    EXAMPLE("상품 예시 이미지"),
+    DESCRIPTION("상품 상세 정보 이미지"),
+    ;
+}

--- a/src/main/kotlin/com/petqua/domain/product/detail/image/ImageType.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/image/ImageType.kt
@@ -4,7 +4,7 @@ enum class ImageType(
     val description: String,
 ) {
 
-    EXAMPLE("상품 예시 이미지"),
+    SAMPLE("상품 예시 이미지"),
     DESCRIPTION("상품 상세 정보 이미지"),
     ;
 }

--- a/src/main/kotlin/com/petqua/domain/product/detail/image/ProductImage.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/image/ProductImage.kt
@@ -1,8 +1,10 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.image
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType.IDENTITY
 import jakarta.persistence.Id
@@ -17,4 +19,8 @@ class ProductImage(
 
     @Column(nullable = false)
     val imageUrl: String,
+
+    @Column(nullable = false)
+    @Enumerated(STRING)
+    val imageType: ImageType,
 ) : BaseEntity()

--- a/src/main/kotlin/com/petqua/domain/product/detail/image/ProductImageRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/image/ProductImageRepository.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.image
 
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/DifficultyLevel.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/DifficultyLevel.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 enum class DifficultyLevel(
     val description: String,

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/OptimalTankSize.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/OptimalTankSize.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 
 enum class OptimalTankSize(

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/OptimalTemperature.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/OptimalTemperature.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 import jakarta.persistence.Column
 import jakarta.persistence.Embeddable

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfo.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfo.kt
@@ -16,9 +16,6 @@ class ProductInfo(
     val id: Long = 0L,
 
     @Column(nullable = false)
-    val productId: Long,
-
-    @Column(nullable = false)
     val categoryId: Long,
 
     @Embedded

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfo.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfo.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 import com.petqua.common.domain.BaseEntity
 import jakarta.persistence.Column

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfoRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/ProductInfoRepository.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/main/kotlin/com/petqua/domain/product/detail/info/Temperament.kt
+++ b/src/main/kotlin/com/petqua/domain/product/detail/info/Temperament.kt
@@ -1,4 +1,4 @@
-package com.petqua.domain.product.detail
+package com.petqua.domain.product.detail.info
 
 enum class Temperament(
     val description: String,

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -6,7 +6,6 @@ import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import com.petqua.domain.product.category.Category
-import com.petqua.domain.product.detail.description.ProductDescription
 import com.petqua.domain.product.detail.info.ProductInfo
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.exception.product.ProductException
@@ -87,7 +86,7 @@ data class ProductWithInfoResponse(
     constructor(
         product: Product,
         storeName: String,
-        productDescription: ProductDescription,
+        productDescription: ProductDescriptionResponse,
         productInfo: ProductInfo,
         category: Category,
         productOption: ProductOption,
@@ -104,8 +103,8 @@ data class ProductWithInfoResponse(
         reviewCount = product.reviewCount,
         reviewAverageScore = product.averageReviewScore(),
         thumbnailUrl = product.thumbnailUrl,
-        descriptionTitle = productDescription.title.value,
-        descriptionContent = productDescription.content.value,
+        descriptionTitle = productDescription.title,
+        descriptionContent = productDescription.content,
         canDeliverSafely = product.canDeliverSafely,
         canDeliverCommonly = product.canDeliverCommonly,
         canPickUp = product.canPickUp,
@@ -117,6 +116,11 @@ data class ProductWithInfoResponse(
         hasDistinctSex = productOption.hasDistinctSex(),
     )
 }
+
+data class ProductDescriptionResponse(
+    val title: String,
+    val content: String,
+)
 
 data class ProductResponse(
     @Schema(

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -6,7 +6,8 @@ import com.petqua.domain.product.Product
 import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import com.petqua.domain.product.category.Category
-import com.petqua.domain.product.detail.ProductInfo
+import com.petqua.domain.product.detail.description.ProductDescription
+import com.petqua.domain.product.detail.info.ProductInfo
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType
@@ -71,7 +72,8 @@ data class ProductWithInfoResponse(
     val reviewCount: Int,
     val reviewAverageScore: Double,
     val thumbnailUrl: String,
-    val description: String,
+    val descriptionTitle: String,
+    val descriptionContent: String,
     val canDeliverSafely: Boolean,
     val canDeliverCommonly: Boolean,
     val canPickUp: Boolean,
@@ -85,6 +87,7 @@ data class ProductWithInfoResponse(
     constructor(
         product: Product,
         storeName: String,
+        productDescription: ProductDescription,
         productInfo: ProductInfo,
         category: Category,
         productOption: ProductOption,
@@ -101,7 +104,8 @@ data class ProductWithInfoResponse(
         reviewCount = product.reviewCount,
         reviewAverageScore = product.averageReviewScore(),
         thumbnailUrl = product.thumbnailUrl,
-        description = product.description,
+        descriptionTitle = productDescription.title.value,
+        descriptionContent = productDescription.content.value,
         canDeliverSafely = product.canDeliverSafely,
         canDeliverCommonly = product.canDeliverCommonly,
         canPickUp = product.canPickUp,

--- a/src/main/kotlin/com/petqua/domain/product/option/ProductOption.kt
+++ b/src/main/kotlin/com/petqua/domain/product/option/ProductOption.kt
@@ -16,9 +16,6 @@ class ProductOption(
     val id: Long = 0L,
 
     @Column(nullable = false)
-    val productId: Long,
-
-    @Column(nullable = false)
     @Enumerated(STRING)
     val sex: Sex,
 

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -17,7 +17,7 @@ import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.detail.description.ProductDescriptionRepository
 import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
-import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ImageType.SAMPLE
 import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.detail.info.DifficultyLevel
 import com.petqua.domain.product.detail.info.OptimalTankSize
@@ -108,7 +108,7 @@ class ProductServiceTest(
             productImage(
                 productId = product.id,
                 imageUrl = "image.jpeg",
-                imageType = EXAMPLE
+                imageType = SAMPLE
             )
         )
         val productDescriptionImage = productImageRepository.save(

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -77,6 +77,26 @@ class ProductServiceTest(
                 species = "고정구피"
             )
         )
+        val productDescription = productDescriptionRepository.save(
+            productDescription(
+                title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+            )
+        )
+        val productInfo = productInfoRepository.save(
+            productInfo(
+                categoryId = category.id,
+                optimalTemperature = OptimalTemperature(26, 28),
+                difficultyLevel = DifficultyLevel.EASY,
+                optimalTankSize = OptimalTankSize.TANK1,
+                temperament = Temperament.PEACEFUL,
+            )
+        )
+        val productOption = productOptionRepository.save(
+            productOption(
+                sex = FEMALE,
+            )
+        )
         val product = productRepository.save(
             product(
                 name = "고정구피",
@@ -84,24 +104,10 @@ class ProductServiceTest(
                 categoryId = category.id,
                 discountPrice = BigDecimal.ZERO,
                 reviewCount = 0,
-                reviewTotalScore = 0
-            )
-        )
-        val productDescription = productDescriptionRepository.save(
-            productDescription(
-                productId = product.id,
-                title = "물생활 핵 인싸어, 레드 브론즈 구피",
-                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
-            )
-        )
-        val productInfo = productInfoRepository.save(
-            productInfo(
-                productId = product.id,
-                categoryId = 0,
-                optimalTemperature = OptimalTemperature(26, 28),
-                difficultyLevel = DifficultyLevel.EASY,
-                optimalTankSize = OptimalTankSize.TANK1,
-                temperament = Temperament.PEACEFUL,
+                reviewTotalScore = 0,
+                productOptionId = productOption.id,
+                productDescriptionId = productDescription.id,
+                productInfoId = productInfo.id,
             )
         )
         val productImage = productImageRepository.save(
@@ -116,12 +122,6 @@ class ProductServiceTest(
                 productId = product.id,
                 imageUrl = "image.jpeg",
                 imageType = DESCRIPTION
-            )
-        )
-        val productOption = productOptionRepository.save(
-            productOption(
-                productId = product.id,
-                sex = FEMALE,
             )
         )
         wishProductRepository.save(

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -15,12 +15,15 @@ import com.petqua.domain.product.ProductSourceType.NONE
 import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.CategoryRepository
-import com.petqua.domain.product.detail.DifficultyLevel
-import com.petqua.domain.product.detail.OptimalTankSize
-import com.petqua.domain.product.detail.OptimalTemperature
-import com.petqua.domain.product.detail.ProductImageRepository
-import com.petqua.domain.product.detail.ProductInfoRepository
-import com.petqua.domain.product.detail.Temperament
+import com.petqua.domain.product.detail.description.ProductDescriptionRepository
+import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
+import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ProductImageRepository
+import com.petqua.domain.product.detail.info.DifficultyLevel
+import com.petqua.domain.product.detail.info.OptimalTankSize
+import com.petqua.domain.product.detail.info.OptimalTemperature
+import com.petqua.domain.product.detail.info.ProductInfoRepository
+import com.petqua.domain.product.detail.info.Temperament
 import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.product.option.Sex.FEMALE
 import com.petqua.domain.store.StoreRepository
@@ -30,6 +33,7 @@ import com.petqua.test.DataCleaner
 import com.petqua.test.fixture.category
 import com.petqua.test.fixture.member
 import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productDescription
 import com.petqua.test.fixture.productDetailResponse
 import com.petqua.test.fixture.productImage
 import com.petqua.test.fixture.productInfo
@@ -58,6 +62,7 @@ class ProductServiceTest(
     private val wishProductRepository: WishProductRepository,
     private val categoryRepository: CategoryRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val productDescriptionRepository: ProductDescriptionRepository,
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
@@ -82,6 +87,13 @@ class ProductServiceTest(
                 reviewTotalScore = 0
             )
         )
+        val productDescription = productDescriptionRepository.save(
+            productDescription(
+                productId = product.id,
+                title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+            )
+        )
         val productInfo = productInfoRepository.save(
             productInfo(
                 productId = product.id,
@@ -95,7 +107,15 @@ class ProductServiceTest(
         val productImage = productImageRepository.save(
             productImage(
                 productId = product.id,
-                imageUrl = "image.jpeg"
+                imageUrl = "image.jpeg",
+                imageType = EXAMPLE
+            )
+        )
+        val productDescriptionImage = productImageRepository.save(
+            productImage(
+                productId = product.id,
+                imageUrl = "image.jpeg",
+                imageType = DESCRIPTION
             )
         )
         val productOption = productOptionRepository.save(
@@ -122,6 +142,8 @@ class ProductServiceTest(
                     product = product,
                     storeName = store.name,
                     imageUrls = listOf(productImage.imageUrl),
+                    productDescription = productDescription,
+                    descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                     productInfo = productInfo,
                     category = category,
                     hasDistinctSex = productOption.hasDistinctSex(),
@@ -155,6 +177,8 @@ class ProductServiceTest(
                     product = product,
                     storeName = store.name,
                     imageUrls = listOf(productImage.imageUrl),
+                    productDescription = productDescription,
+                    descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                     productInfo = productInfo,
                     category = category,
                     hasDistinctSex = productOption.hasDistinctSex(),

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -10,11 +10,12 @@ import com.petqua.domain.product.Sorter.REVIEW_COUNT_DESC
 import com.petqua.domain.product.Sorter.SALE_PRICE_ASC
 import com.petqua.domain.product.Sorter.SALE_PRICE_DESC
 import com.petqua.domain.product.category.CategoryRepository
-import com.petqua.domain.product.detail.DifficultyLevel.EASY
-import com.petqua.domain.product.detail.OptimalTankSize
-import com.petqua.domain.product.detail.OptimalTemperature
-import com.petqua.domain.product.detail.ProductInfoRepository
-import com.petqua.domain.product.detail.Temperament.PEACEFUL
+import com.petqua.domain.product.detail.description.ProductDescriptionRepository
+import com.petqua.domain.product.detail.info.DifficultyLevel.EASY
+import com.petqua.domain.product.detail.info.OptimalTankSize
+import com.petqua.domain.product.detail.info.OptimalTemperature
+import com.petqua.domain.product.detail.info.ProductInfoRepository
+import com.petqua.domain.product.detail.info.Temperament.PEACEFUL
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
@@ -28,6 +29,7 @@ import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.test.DataCleaner
 import com.petqua.test.fixture.category
 import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productDescription
 import com.petqua.test.fixture.productInfo
 import com.petqua.test.fixture.productOption
 import com.petqua.test.fixture.productRecommendation
@@ -51,6 +53,7 @@ class ProductCustomRepositoryImplTest(
     private val productInfoRepository: ProductInfoRepository,
     private val categoryRepository: CategoryRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val productDescriptionRepository: ProductDescriptionRepository,
     private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
@@ -71,6 +74,13 @@ class ProductCustomRepositoryImplTest(
                 discountPrice = ZERO,
                 reviewCount = 0,
                 reviewTotalScore = 0
+            )
+        )
+        val productDescription = productDescriptionRepository.save(
+            productDescription(
+                productId = product.id,
+                title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
             )
         )
         val productInfo = productInfoRepository.save(
@@ -99,6 +109,7 @@ class ProductCustomRepositoryImplTest(
                 productWithInfoResponse shouldBe ProductWithInfoResponse(
                     product = product,
                     storeName = store.name,
+                    productDescription = productDescription,
                     productInfo = productInfo,
                     category = category,
                     productOption = productOption,

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -67,6 +67,40 @@ class ProductCustomRepositoryImplTest(
                 species = "고정구피"
             )
         )
+        val productInfo1 = productInfoRepository.save(
+            productInfo(
+                categoryId = category.id,
+                optimalTemperature = OptimalTemperature(26, 28),
+                difficultyLevel = EASY,
+                optimalTankSize = OptimalTankSize.TANK1,
+                temperament = PEACEFUL,
+            )
+        )
+        val productInfo2 = productInfoRepository.save(
+            productInfo(
+                categoryId = category.id,
+                optimalTemperature = OptimalTemperature(26, 28),
+                difficultyLevel = EASY,
+                optimalTankSize = OptimalTankSize.TANK1,
+                temperament = PEACEFUL,
+            )
+        )
+        val productOption1 = productOptionRepository.save(
+            productOption(
+                sex = Sex.MALE,
+            )
+        )
+        val productOption2 = productOptionRepository.save(
+            productOption(
+                sex = Sex.MALE,
+            )
+        )
+        val productDescription1 = productDescriptionRepository.save(
+            productDescription(
+                title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+            )
+        )
         val product1 = productRepository.save(
             product(
                 name = "고정구피",
@@ -74,7 +108,10 @@ class ProductCustomRepositoryImplTest(
                 categoryId = category.id,
                 discountPrice = ZERO,
                 reviewCount = 0,
-                reviewTotalScore = 0
+                reviewTotalScore = 0,
+                productOptionId = productOption1.id,
+                productDescriptionId = productDescription1.id,
+                productInfoId = productInfo1.id,
             )
         )
         val product2 = productRepository.save(
@@ -84,46 +121,9 @@ class ProductCustomRepositoryImplTest(
                 categoryId = category.id,
                 discountPrice = ZERO,
                 reviewCount = 0,
-                reviewTotalScore = 0
-            )
-        )
-        val productInfo1 = productInfoRepository.save(
-            productInfo(
-                productId = product1.id,
-                categoryId = 0,
-                optimalTemperature = OptimalTemperature(26, 28),
-                difficultyLevel = EASY,
-                optimalTankSize = OptimalTankSize.TANK1,
-                temperament = PEACEFUL,
-            )
-        )
-        val productInfo2 = productInfoRepository.save(
-            productInfo(
-                productId = product2.id,
-                categoryId = 0,
-                optimalTemperature = OptimalTemperature(26, 28),
-                difficultyLevel = EASY,
-                optimalTankSize = OptimalTankSize.TANK1,
-                temperament = PEACEFUL,
-            )
-        )
-        val productOption1 = productOptionRepository.save(
-            productOption(
-                productId = product1.id,
-                sex = Sex.MALE,
-            )
-        )
-        val productOption2 = productOptionRepository.save(
-            productOption(
-                productId = product2.id,
-                sex = Sex.MALE,
-            )
-        )
-        val productDescription1 = productDescriptionRepository.save(
-            productDescription(
-                productId = product1.id,
-                title = "물생활 핵 인싸어, 레드 브론즈 구피",
-                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+                reviewTotalScore = 0,
+                productOptionId = productOption2.id,
+                productInfoId = productInfo2.id,
             )
         )
 

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -16,6 +16,7 @@ import com.petqua.domain.product.detail.info.OptimalTankSize
 import com.petqua.domain.product.detail.info.OptimalTemperature
 import com.petqua.domain.product.detail.info.ProductInfoRepository
 import com.petqua.domain.product.detail.info.Temperament.PEACEFUL
+import com.petqua.domain.product.dto.ProductDescriptionResponse
 import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
@@ -66,7 +67,7 @@ class ProductCustomRepositoryImplTest(
                 species = "고정구피"
             )
         )
-        val product = productRepository.save(
+        val product1 = productRepository.save(
             product(
                 name = "고정구피",
                 storeId = store.id,
@@ -76,16 +77,19 @@ class ProductCustomRepositoryImplTest(
                 reviewTotalScore = 0
             )
         )
-        val productDescription = productDescriptionRepository.save(
-            productDescription(
-                productId = product.id,
-                title = "물생활 핵 인싸어, 레드 브론즈 구피",
-                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+        val product2 = productRepository.save(
+            product(
+                name = "팬시구피",
+                storeId = store.id,
+                categoryId = category.id,
+                discountPrice = ZERO,
+                reviewCount = 0,
+                reviewTotalScore = 0
             )
         )
-        val productInfo = productInfoRepository.save(
+        val productInfo1 = productInfoRepository.save(
             productInfo(
-                productId = product.id,
+                productId = product1.id,
                 categoryId = 0,
                 optimalTemperature = OptimalTemperature(26, 28),
                 difficultyLevel = EASY,
@@ -93,26 +97,72 @@ class ProductCustomRepositoryImplTest(
                 temperament = PEACEFUL,
             )
         )
-        val productOption = productOptionRepository.save(
+        val productInfo2 = productInfoRepository.save(
+            productInfo(
+                productId = product2.id,
+                categoryId = 0,
+                optimalTemperature = OptimalTemperature(26, 28),
+                difficultyLevel = EASY,
+                optimalTankSize = OptimalTankSize.TANK1,
+                temperament = PEACEFUL,
+            )
+        )
+        val productOption1 = productOptionRepository.save(
             productOption(
-                productId = product.id,
+                productId = product1.id,
                 sex = Sex.MALE,
+            )
+        )
+        val productOption2 = productOptionRepository.save(
+            productOption(
+                productId = product2.id,
+                sex = Sex.MALE,
+            )
+        )
+        val productDescription1 = productDescriptionRepository.save(
+            productDescription(
+                productId = product1.id,
+                title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
             )
         )
 
         When("Id를 입력하면") {
-            val productWithInfoResponse = productRepository.findProductWithInfoByIdOrThrow(product.id) {
+            val productWithInfoResponse = productRepository.findProductWithInfoByIdOrThrow(product1.id) {
                 ProductException(NOT_FOUND_PRODUCT)
             }
 
             Then("입력한 Id의 상품과 상세정보가 반환된다") {
                 productWithInfoResponse shouldBe ProductWithInfoResponse(
-                    product = product,
+                    product = product1,
                     storeName = store.name,
-                    productDescription = productDescription,
-                    productInfo = productInfo,
+                    productDescription = ProductDescriptionResponse(
+                        title = productDescription1.title.value,
+                        content = productDescription1.content.value
+                    ),
+                    productInfo = productInfo1,
                     category = category,
-                    productOption = productOption,
+                    productOption = productOption1,
+                )
+            }
+        }
+
+        When("상세 설명이 없는 상품의 Id를 입력하면") {
+            val productWithInfoResponse = productRepository.findProductWithInfoByIdOrThrow(product2.id) {
+                ProductException(NOT_FOUND_PRODUCT)
+            }
+
+            Then("상세 설명이 없이 입력한 Id의 상품과 상세정보가 반환된다") {
+                productWithInfoResponse shouldBe ProductWithInfoResponse(
+                    product = product2,
+                    storeName = store.name,
+                    productDescription = ProductDescriptionResponse(
+                        title = "",
+                        content = ""
+                    ),
+                    productInfo = productInfo2,
+                    category = category,
+                    productOption = productOption2,
                 )
             }
         }

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
@@ -83,6 +83,26 @@ class ProductControllerTest(
                     species = "고정구피"
                 )
             )
+            val productDescription = productDescriptionRepository.save(
+                productDescription(
+                    title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                    content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+                )
+            )
+            val productInfo = productInfoRepository.save(
+                productInfo(
+                    categoryId = category.id,
+                    optimalTemperature = OptimalTemperature(26, 28),
+                    difficultyLevel = DifficultyLevel.EASY,
+                    optimalTankSize = OptimalTankSize.TANK1,
+                    temperament = Temperament.PEACEFUL,
+                )
+            )
+            val productOption = productOptionRepository.save(
+                productOption(
+                    sex = HERMAPHRODITE
+                )
+            )
             val product = productRepository.save(
                 product(
                     name = "고정구피",
@@ -90,24 +110,10 @@ class ProductControllerTest(
                     storeId = store.id,
                     discountPrice = ZERO,
                     reviewCount = 0,
-                    reviewTotalScore = 0
-                )
-            )
-            val productDescription = productDescriptionRepository.save(
-                productDescription(
-                    productId = product.id,
-                    title = "물생활 핵 인싸어, 레드 브론즈 구피",
-                    content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
-                )
-            )
-            val productInfo = productInfoRepository.save(
-                productInfo(
-                    productId = product.id,
-                    categoryId = 0,
-                    optimalTemperature = OptimalTemperature(26, 28),
-                    difficultyLevel = DifficultyLevel.EASY,
-                    optimalTankSize = OptimalTankSize.TANK1,
-                    temperament = Temperament.PEACEFUL,
+                    reviewTotalScore = 0,
+                    productOptionId = productOption.id,
+                    productDescriptionId = productDescription.id,
+                    productInfoId = productInfo.id
                 )
             )
             val productImage = productImageRepository.save(
@@ -124,12 +130,7 @@ class ProductControllerTest(
                     imageType = ImageType.DESCRIPTION
                 )
             )
-            val productOption = productOptionRepository.save(
-                productOption(
-                    productId = product.id,
-                    sex = HERMAPHRODITE
-                )
-            )
+
             wishProductRepository.save(
                 wishProduct(
                     productId = product.id,

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
@@ -17,7 +17,7 @@ import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.CategoryRepository
 import com.petqua.domain.product.detail.description.ProductDescriptionRepository
 import com.petqua.domain.product.detail.image.ImageType
-import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ImageType.SAMPLE
 import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.detail.info.DifficultyLevel
 import com.petqua.domain.product.detail.info.OptimalTankSize
@@ -114,7 +114,7 @@ class ProductControllerTest(
                 productImage(
                     productId = product.id,
                     imageUrl = "image.jpeg",
-                    imageType = EXAMPLE
+                    imageType = SAMPLE
                 )
             )
             val productDescriptionImage = productImageRepository.save(

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
@@ -15,12 +15,15 @@ import com.petqua.domain.product.Sorter.SALE_PRICE_ASC
 import com.petqua.domain.product.Sorter.SALE_PRICE_DESC
 import com.petqua.domain.product.WishProductRepository
 import com.petqua.domain.product.category.CategoryRepository
-import com.petqua.domain.product.detail.DifficultyLevel
-import com.petqua.domain.product.detail.OptimalTankSize
-import com.petqua.domain.product.detail.OptimalTemperature
-import com.petqua.domain.product.detail.ProductImageRepository
-import com.petqua.domain.product.detail.ProductInfoRepository
-import com.petqua.domain.product.detail.Temperament
+import com.petqua.domain.product.detail.description.ProductDescriptionRepository
+import com.petqua.domain.product.detail.image.ImageType
+import com.petqua.domain.product.detail.image.ImageType.EXAMPLE
+import com.petqua.domain.product.detail.image.ProductImageRepository
+import com.petqua.domain.product.detail.info.DifficultyLevel
+import com.petqua.domain.product.detail.info.OptimalTankSize
+import com.petqua.domain.product.detail.info.OptimalTemperature
+import com.petqua.domain.product.detail.info.ProductInfoRepository
+import com.petqua.domain.product.detail.info.Temperament
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.product.option.Sex.HERMAPHRODITE
@@ -31,6 +34,7 @@ import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.category
 import com.petqua.test.fixture.product
+import com.petqua.test.fixture.productDescription
 import com.petqua.test.fixture.productDetailResponse
 import com.petqua.test.fixture.productImage
 import com.petqua.test.fixture.productInfo
@@ -63,6 +67,7 @@ class ProductControllerTest(
     private val wishProductRepository: WishProductRepository,
     private val categoryRepository: CategoryRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val productDescriptionRepository: ProductDescriptionRepository,
 ) : ApiTestConfig() {
 
     init {
@@ -88,6 +93,13 @@ class ProductControllerTest(
                     reviewTotalScore = 0
                 )
             )
+            val productDescription = productDescriptionRepository.save(
+                productDescription(
+                    productId = product.id,
+                    title = "물생활 핵 인싸어, 레드 브론즈 구피",
+                    content = "레드 턱시도라고도 불리며 지느러미가 아름다운 구피입니다"
+                )
+            )
             val productInfo = productInfoRepository.save(
                 productInfo(
                     productId = product.id,
@@ -101,7 +113,15 @@ class ProductControllerTest(
             val productImage = productImageRepository.save(
                 productImage(
                     productId = product.id,
-                    imageUrl = "image.jpeg"
+                    imageUrl = "image.jpeg",
+                    imageType = EXAMPLE
+                )
+            )
+            val productDescriptionImage = productImageRepository.save(
+                productImage(
+                    productId = product.id,
+                    imageUrl = "image.jpeg",
+                    imageType = ImageType.DESCRIPTION
                 )
             )
             val productOption = productOptionRepository.save(
@@ -132,6 +152,8 @@ class ProductControllerTest(
                             product = product,
                             storeName = store.name,
                             imageUrls = listOf(productImage.imageUrl),
+                            productDescription = productDescription,
+                            descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                             productInfo = productInfo,
                             category = category,
                             hasDistinctSex = productOption.hasDistinctSex(),
@@ -172,6 +194,8 @@ class ProductControllerTest(
                             product = product,
                             storeName = store.name,
                             imageUrls = listOf(productImage.imageUrl),
+                            productDescription = productDescription,
+                            descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                             productInfo = productInfo,
                             category = category,
                             hasDistinctSex = productOption.hasDistinctSex(),

--- a/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
@@ -38,6 +38,9 @@ fun product(
     canDeliverySafely: Boolean = true,
     canDeliveryCommonly: Boolean = true,
     canPickUp: Boolean = true,
+    productOptionId: Long = 0,
+    productDescriptionId: Long? = null,
+    productInfoId: Long = 0,
 ): Product {
     return Product(
         id = id,
@@ -55,6 +58,9 @@ fun product(
         canDeliverSafely = canDeliverySafely,
         canDeliverCommonly = canDeliveryCommonly,
         canPickUp = canPickUp,
+        productOptionId = productOptionId,
+        productDescriptionId = productDescriptionId,
+        productInfoId = productInfoId
     )
 }
 
@@ -72,7 +78,6 @@ fun productKeyword(
 
 fun productInfo(
     id: Long = 0L,
-    productId: Long,
     categoryId: Long,
     optimalTemperature: OptimalTemperature,
     difficultyLevel: DifficultyLevel,
@@ -81,7 +86,6 @@ fun productInfo(
 ): ProductInfo {
     return ProductInfo(
         id = id,
-        productId = productId,
         categoryId = categoryId,
         optimalTemperature = optimalTemperature,
         difficultyLevel = difficultyLevel,
@@ -106,13 +110,11 @@ fun productImage(
 
 fun productOption(
     id: Long = 0,
-    productId: Long,
     sex: Sex,
     additionalPrice: BigDecimal = BigDecimal.ZERO,
 ): ProductOption {
     return ProductOption(
         id = id,
-        productId = productId,
         sex = sex,
         additionalPrice = additionalPrice,
     )
@@ -120,13 +122,11 @@ fun productOption(
 
 fun productDescription(
     id: Long = 0,
-    productId: Long,
     title: String = "제목",
     content: String = "내용",
 ): ProductDescription {
     return ProductDescription(
         id = id,
-        productId = productId,
         title = ProductDescriptionTitle(title),
         content = ProductDescriptionContent(content)
     )

--- a/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
@@ -5,12 +5,16 @@ import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.WishCount
 import com.petqua.domain.product.category.Category
-import com.petqua.domain.product.detail.DifficultyLevel
-import com.petqua.domain.product.detail.OptimalTankSize
-import com.petqua.domain.product.detail.OptimalTemperature
-import com.petqua.domain.product.detail.ProductImage
-import com.petqua.domain.product.detail.ProductInfo
-import com.petqua.domain.product.detail.Temperament
+import com.petqua.domain.product.detail.description.ProductDescription
+import com.petqua.domain.product.detail.description.ProductDescriptionContent
+import com.petqua.domain.product.detail.description.ProductDescriptionTitle
+import com.petqua.domain.product.detail.image.ImageType
+import com.petqua.domain.product.detail.image.ProductImage
+import com.petqua.domain.product.detail.info.DifficultyLevel
+import com.petqua.domain.product.detail.info.OptimalTankSize
+import com.petqua.domain.product.detail.info.OptimalTemperature
+import com.petqua.domain.product.detail.info.ProductInfo
+import com.petqua.domain.product.detail.info.Temperament
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.product.option.Sex
@@ -30,29 +34,27 @@ fun product(
     reviewCount: Int = 0,
     reviewTotalScore: Int = 0,
     thumbnailUrl: String = "image.jpg",
-    description: String = "description",
     isDeleted: Boolean = false,
     canDeliverySafely: Boolean = true,
     canDeliveryCommonly: Boolean = true,
     canPickUp: Boolean = true,
 ): Product {
     return Product(
-        id,
-        name,
-        categoryId,
-        price.setScale(DEFAULT_SCALE),
-        storeId,
-        discountRate,
-        discountPrice.setScale(DEFAULT_SCALE),
-        WishCount(wishCount),
-        reviewCount,
-        reviewTotalScore,
-        thumbnailUrl,
-        description,
-        isDeleted,
-        canDeliverySafely,
-        canDeliveryCommonly,
-        canPickUp,
+        id = id,
+        name = name,
+        categoryId = categoryId,
+        price = price.setScale(DEFAULT_SCALE),
+        storeId = storeId,
+        discountRate = discountRate,
+        discountPrice = discountPrice.setScale(DEFAULT_SCALE),
+        wishCount = WishCount(wishCount),
+        reviewCount = reviewCount,
+        reviewTotalScore = reviewTotalScore,
+        thumbnailUrl = thumbnailUrl,
+        isDeleted = isDeleted,
+        canDeliverSafely = canDeliverySafely,
+        canDeliverCommonly = canDeliveryCommonly,
+        canPickUp = canPickUp,
     )
 }
 
@@ -92,11 +94,13 @@ fun productImage(
     id: Long = 0,
     productId: Long,
     imageUrl: String,
+    imageType: ImageType,
 ): ProductImage {
     return ProductImage(
         id = id,
         productId = productId,
         imageUrl = imageUrl,
+        imageType = imageType,
     )
 }
 
@@ -114,10 +118,26 @@ fun productOption(
     )
 }
 
+fun productDescription(
+    id: Long = 0,
+    productId: Long,
+    title: String = "제목",
+    content: String = "내용",
+): ProductDescription {
+    return ProductDescription(
+        id = id,
+        productId = productId,
+        title = ProductDescriptionTitle(title),
+        content = ProductDescriptionContent(content)
+    )
+}
+
 fun productDetailResponse(
     product: Product,
     storeName: String,
     imageUrls: List<String>,
+    productDescription: ProductDescription,
+    descriptionImageUrls: List<String>,
     productInfo: ProductInfo,
     category: Category,
     hasDistinctSex: Boolean,
@@ -135,9 +155,10 @@ fun productDetailResponse(
         wishCount = product.wishCount.value,
         reviewCount = product.reviewCount,
         reviewAverageScore = product.averageReviewScore(),
-        thumbnailUrl = product.thumbnailUrl,
         imageUrls = imageUrls,
-        description = product.description,
+        descriptionTitle = productDescription.title.value,
+        descriptionContent = productDescription.content.value,
+        descriptionImageUrls = descriptionImageUrls,
         canDeliverSafely = product.canDeliverSafely,
         canDeliverCommonly = product.canDeliverCommonly,
         canPickUp = product.canPickUp,


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #87 

### 📁 작업 설명

- 상품 상세 조회 API의 응답을 변경했습니다.

```json
{
  "id": 98,
  "name": "팬시구피1",
  "family": "송사리과",
  "species": "팬시구피",
  "price": 80000,
  "storeName": "상점1",
  "discountRate": 50,
  "discountPrice": 40000,
  "wishCount": 100,
  "reviewCount": 4,
  "reviewAverageScore": 2.5,
  "imageUrls": [
    "https://docs.petqua.co.kr/products/thumbnails/image1.jpeg",
    "https://docs.petqua.co.kr/products/thumbnails/image2.jpeg",
    "https://docs.petqua.co.kr/products/thumbnails/image3.jpeg"
  ],
  "descriptionTitle" : "설명 제목",
  "descriptionContent": "설명 내용",
  "descriptionImageUrls" : [
    "https://docs.petqua.co.kr/products/thumbnails/image1.jpeg",
    "https://docs.petqua.co.kr/products/thumbnails/image2.jpeg",
  ],
  "canDeliverSafely": false,
  "canDeliverCommonly": false,
  "canPickUp": false,
  "optimalTemperatureMin": 22,
  "optimalTemperatureMax": 25,
  "difficultyLevel": "중",
  "optimalTankSize": "2자어항",
  "temperament": "온순함",
  "hasDistinctSex": false,
  "isWished": false
}
``` 

- ProductDescription 객체를 추가했습니다.
펫프렌즈 예시 화면과 같이 Description 은 제목과 내용으로 나뉜다고 합니다(피그마에 반영되어 있지는 않음). 이를 반영하기 위해 Content, Title을 만들었습니다. 그리고 Product 객체가 이러한 변경의 영향을 받지 않도록 Description Entity를 따로 분리했습니다.

<img src="https://github.com/petqua/backend/assets/106813090/66785a42-3cef-4037-abd4-3292e2b27103" height="400">


- ProductImage 테이블에서 상품 예시 이미지와 상품 상세 보기 이미지를 모두 관리할 수 있도록 imageType 컬럼을 추가했습니다.
