### PR TITLE
fix: 상품 옵션 더미 데이터 추가 로직 변경

### DIFF
--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -32,6 +32,7 @@ import com.petqua.domain.product.detail.info.OptimalTemperature
 import com.petqua.domain.product.detail.info.ProductInfo
 import com.petqua.domain.product.detail.info.ProductInfoRepository
 import com.petqua.domain.product.detail.info.Temperament.PEACEFUL
+import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.product.option.Sex.FEMALE
 import com.petqua.domain.product.option.Sex.HERMAPHRODITE
@@ -45,13 +46,13 @@ import com.petqua.domain.recommendation.ProductRecommendation
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
-import java.math.BigDecimal
-import kotlin.random.Random
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import kotlin.random.Random
 
 @Component
 @Profile("local", "prod")
@@ -171,18 +172,6 @@ class DataInitializer(
             }
             val reviewCount = (1..5).random()
 
-            val sex = when {
-                (it % 3) == 0 -> MALE
-                (it % 7) == 0 -> FEMALE
-                else -> HERMAPHRODITE
-            }
-//            val productOption = productOptionRepository.save(
-//                ProductOption(
-//                    sex = sex,
-//                    additionalPrice = BigDecimal.ZERO
-//                )
-//            )
-
             val productInfo = productInfoRepository.save(
                 ProductInfo(
                     categoryId = categoryId,
@@ -223,6 +212,21 @@ class DataInitializer(
             )
         }
         productRepository.saveAll(products)
+
+        val productOptions = products.map {
+            val sex = when {
+                (it.id % 3).toInt() == 0 -> MALE
+                (it.id % 7).toInt() == 0 -> FEMALE
+                else -> HERMAPHRODITE
+            }
+
+            ProductOption(
+                productId = it.id,
+                sex = sex,
+                additionalPrice = BigDecimal.ZERO,
+            )
+        }
+        productOptionRepository.saveAll(productOptions)
 
         // wishProducts
         val wishProducts = products.filter {

--- a/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
@@ -2,21 +2,30 @@ package com.petqua.presentation.order
 
 import com.petqua.application.order.OrderService
 import com.petqua.application.order.dto.SaveOrderResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.order.dto.SaveOrderRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Order", description = "주문 관련 API 명세")
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @RequestMapping("/orders")
 @RestController
 class OrderController(
     private val orderService: OrderService,
 ) {
 
+    @Operation(summary = "주문 생성 API", description = "주문을 생성합니다")
+    @ApiResponse(responseCode = "200", description = "주문 생성 성공")
     @PostMapping
     fun save(
         @Auth loginMember: LoginMember,

--- a/src/test/kotlin/com/petqua/domain/product/ProductTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductTest.kt
@@ -1,10 +1,8 @@
 package com.petqua.domain.product
 
-import com.petqua.domain.order.OrderNumber
 import com.petqua.test.fixture.product
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Test
 
 class ProductTest : BehaviorSpec({
 
@@ -24,9 +22,4 @@ class ProductTest : BehaviorSpec({
     }
 
 
-}) {
-    @Test
-    fun test() {
-        println(OrderNumber.generate().value)
-    }
-}
+})


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #103 

### 📁 작업 설명

- 상품 옵션 더미 데이터가 없어서, 상품 상세 조회 api 가 제대로 동작하지 않습니다. 따라서 더미 데이터 생성 로직을 추가했습니다.
- 출력을 포함한 테스트를 삭제했습니다.
- 간단히 Swagger 를 애노테이션을 붙여두었습니다.