### PR TITLE
feature: 봉달 관련 api 스펙 수정

### DIFF
--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -7,17 +7,21 @@ import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.common.domain.existActiveByIdOrThrow
 import com.petqua.common.domain.existByIdOrThrow
 import com.petqua.common.domain.findByIdOrThrow
+import com.petqua.common.util.throwExceptionWhen
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.product.ProductRepository
+import com.petqua.domain.product.option.Sex
 import com.petqua.exception.cart.CartProductException
+import com.petqua.exception.cart.CartProductExceptionType.DIFFERENT_DELIVERY_FEE
 import com.petqua.exception.cart.CartProductExceptionType.DUPLICATED_PRODUCT
 import com.petqua.exception.cart.CartProductExceptionType.NOT_FOUND_CART_PRODUCT
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
+import java.math.BigDecimal
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -35,9 +39,10 @@ class CartProductService(
         validateDuplicatedProduct(
             memberId = command.memberId,
             productId = command.productId,
-            isMale = command.isMale,
+            sex = command.sex,
             deliveryMethod = command.deliveryMethod
         )
+        validateDeliveryFee(command.productId, command.deliveryMethod, command.deliveryFee)
         return cartProductRepository.save(command.toCartProduct()).id
     }
 
@@ -50,22 +55,34 @@ class CartProductService(
         validateDuplicatedProduct(
             memberId = command.memberId,
             productId = cartProduct.productId,
-            isMale = command.isMale,
+            sex = command.sex,
             deliveryMethod = command.deliveryMethod
         )
-        cartProduct.updateOptions(command.quantity, command.isMale, command.deliveryMethod)
+        validateDeliveryFee(cartProduct.productId, command.deliveryMethod, command.deliveryFee)
+        cartProduct.updateOptions(
+            command.quantity,
+            command.sex,
+            command.deliveryMethod,
+            command.deliveryFee
+        )
+    }
+
+    private fun validateDeliveryFee(productId: Long, deliveryMethod: DeliveryMethod, deliveryFee: BigDecimal) {
+        productRepository.findByIdOrThrow(productId, ProductException(NOT_FOUND_PRODUCT))
+            .getDeliveryFee(deliveryMethod)
+            .also { throwExceptionWhen(it != deliveryFee) { CartProductException(DIFFERENT_DELIVERY_FEE) } }
     }
 
     private fun validateDuplicatedProduct(
         memberId: Long,
         productId: Long,
-        isMale: Boolean,
+        sex: Sex,
         deliveryMethod: DeliveryMethod
     ) {
-        cartProductRepository.findByMemberIdAndProductIdAndIsMaleAndDeliveryMethod(
+        cartProductRepository.findByMemberIdAndProductIdAndSexAndDeliveryMethod(
             memberId = memberId,
             productId = productId,
-            isMale = isMale,
+            sex = sex,
             deliveryMethod = deliveryMethod
         )?.also { throw CartProductException(DUPLICATED_PRODUCT) }
     }

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -43,7 +43,7 @@ data class DeleteCartProductCommand(
     val cartProductId: Long,
 )
 
-data class CartProductResponse(
+data class CartProductWithSupportedOptionResponse(
     @Schema(
         description = "봉달(장바구니) 상품 id",
         example = "1"
@@ -123,9 +123,89 @@ data class CartProductResponse(
         example = "true"
     )
     val isOnSale: Boolean,
+
+
+    @Schema(
+        description = "안전 배송 가격 (null인 경우 지원 X)",
+        example = "5000"
+    )
+    val safeDeliveryFee: BigDecimal?,
+
+    @Schema(
+        description = "일반 배송 가격 (null인 경우 지원 X)",
+        example = "3000"
+    )
+    val commonDeliveryFee: BigDecimal?,
+
+    @Schema(
+        description = "픽업 배송 가격 (null인 경우 지원 X)",
+        example = "0"
+    )
+    val pickUpDeliveryFee: BigDecimal?,
+
+    @Schema(
+        description = "수컷 추가 가격 (null인 경우 지원 X)",
+        example = "1000"
+    )
+    val maleAdditionalPrice: BigDecimal?,
+
+    @Schema(
+        description = "암컷 추가 가격 (null인 경우 지원 X)",
+        example = "1000"
+    )
+    val femaleAdditionalPrice: BigDecimal?,
 ) {
 
-    constructor(cartProduct: CartProduct, product: Product?, storeName: String?) : this(
+    constructor(
+        cartProductResponse: CartProductResponse,
+        maleAdditionalPrice: BigDecimal?,
+        femaleAdditionalPrice: BigDecimal?,
+    ) : this(
+        id = cartProductResponse.id,
+        storeName = cartProductResponse.storeName,
+        productId = cartProductResponse.productId,
+        productName = cartProductResponse.productName,
+        productThumbnailUrl = cartProductResponse.productThumbnailUrl,
+        productPrice = cartProductResponse.productPrice,
+        productDiscountRate = cartProductResponse.productDiscountRate,
+        productDiscountPrice = cartProductResponse.productDiscountPrice,
+        quantity = cartProductResponse.quantity,
+        sex = cartProductResponse.sex,
+        deliveryMethod = cartProductResponse.deliveryMethod,
+        deliveryFee = cartProductResponse.deliveryFee,
+        isOnSale = cartProductResponse.isOnSale,
+        safeDeliveryFee = cartProductResponse.safeDeliveryFee,
+        commonDeliveryFee = cartProductResponse.commonDeliveryFee,
+        pickUpDeliveryFee = cartProductResponse.pickUpDeliveryFee,
+        maleAdditionalPrice = maleAdditionalPrice,
+        femaleAdditionalPrice = femaleAdditionalPrice,
+    )
+}
+
+data class CartProductResponse(
+    val id: Long,
+    val storeName: String,
+    val productId: Long,
+    val productName: String,
+    val productThumbnailUrl: String,
+    val productPrice: Int,
+    val productDiscountRate: Int,
+    val productDiscountPrice: Int,
+    val quantity: Int,
+    val sex: Sex,
+    val deliveryMethod: String,
+    val deliveryFee: BigDecimal,
+    val isOnSale: Boolean,
+    val safeDeliveryFee: BigDecimal?,
+    val commonDeliveryFee: BigDecimal?,
+    val pickUpDeliveryFee: BigDecimal?,
+) {
+
+    constructor(
+        cartProduct: CartProduct,
+        product: Product?,
+        storeName: String?,
+    ) : this(
         id = cartProduct.id,
         storeName = storeName ?: "",
         productId = product?.id ?: 0L,
@@ -138,6 +218,9 @@ data class CartProductResponse(
         sex = cartProduct.sex,
         deliveryMethod = cartProduct.deliveryMethod.name,
         deliveryFee = cartProduct.deliveryFee,
-        isOnSale = product != null
+        isOnSale = product != null,
+        safeDeliveryFee = product?.safeDeliveryFee,
+        commonDeliveryFee = product?.commonDeliveryFee,
+        pickUpDeliveryFee = product?.pickUpDeliveryFee,
     )
 }

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -4,22 +4,26 @@ import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.Product
+import com.petqua.domain.product.option.Sex
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 
 data class SaveCartProductCommand(
     val memberId: Long,
     val productId: Long,
     val quantity: Int,
-    val isMale: Boolean,
+    val sex: Sex,
     val deliveryMethod: DeliveryMethod,
+    val deliveryFee: BigDecimal,
 ) {
     fun toCartProduct(): CartProduct {
         return CartProduct(
             memberId = memberId,
             productId = productId,
             quantity = CartProductQuantity(quantity),
-            isMale = isMale,
+            sex = sex,
             deliveryMethod = deliveryMethod,
+            deliveryFee = deliveryFee.setScale(2),
         )
     }
 }
@@ -29,8 +33,9 @@ data class UpdateCartProductOptionCommand(
     val memberId: Long,
     val cartProductId: Long,
     val quantity: CartProductQuantity,
-    val isMale: Boolean,
+    val sex: Sex,
     val deliveryMethod: DeliveryMethod,
+    val deliveryFee: BigDecimal,
 )
 
 data class DeleteCartProductCommand(
@@ -94,11 +99,11 @@ data class CartProductResponse(
     val quantity: Int,
 
     @Schema(
-        description = "수컷 여부",
-        example = "true",
-        allowableValues = ["true", "false"]
+        description = "성별",
+        example = "MALE",
+        allowableValues = ["MALE", "FEMALE", "HERMAPHRODITE"]
     )
-    val isMale: Boolean,
+    val sex: Sex,
 
     @Schema(
         description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
@@ -106,6 +111,12 @@ data class CartProductResponse(
         allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
     )
     val deliveryMethod: String,
+
+    @Schema(
+        description = "배송비",
+        example = "3000"
+    )
+    val deliveryFee: BigDecimal,
 
     @Schema(
         description = "판매 여부(품절 및 삭제 확인)",
@@ -124,8 +135,9 @@ data class CartProductResponse(
         productDiscountRate = product?.discountRate ?: 0,
         productDiscountPrice = product?.discountPrice?.intValueExact() ?: 0,
         quantity = cartProduct.quantity.value,
-        isMale = cartProduct.isMale,
+        sex = cartProduct.sex,
         deliveryMethod = cartProduct.deliveryMethod.name,
+        deliveryFee = cartProduct.deliveryFee,
         isOnSale = product != null
     )
 }

--- a/src/main/kotlin/com/petqua/application/product/ProductService.kt
+++ b/src/main/kotlin/com/petqua/application/product/ProductService.kt
@@ -15,6 +15,9 @@ import com.petqua.domain.product.detail.image.ImageType.DESCRIPTION
 import com.petqua.domain.product.detail.image.ImageType.SAMPLE
 import com.petqua.domain.product.detail.image.ProductImageRepository
 import com.petqua.domain.product.dto.ProductResponse
+import com.petqua.domain.product.option.ProductOptionRepository
+import com.petqua.domain.product.option.Sex.FEMALE
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import org.springframework.stereotype.Service
@@ -25,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional
 class ProductService(
     private val productRepository: ProductRepository,
     private val productImageRepository: ProductImageRepository,
+    private val productOptionRepository: ProductOptionRepository,
     private val productKeywordRepository: ProductKeywordRepository,
     private val wishProductRepository: WishProductRepository,
 ) {
@@ -40,12 +44,17 @@ class ProductService(
             productId = productId,
             memberId = loginMemberOrGuest.memberId
         )
+        val productOptions = productOptionRepository.findAllByProductId(productId)
+        val maleAdditionalPrice = productOptions.find { it.sex == MALE }?.additionalPrice
+        val femaleAdditionalPrice = productOptions.find { it.sex == FEMALE }?.additionalPrice
 
         return ProductDetailResponse(
             productWithInfoResponse = productWithInfo,
             imageUrls = imagesByType[SAMPLE] ?: emptyList(),
             descriptionImageUrls = imagesByType[DESCRIPTION] ?: emptyList(),
-            isWished = isWished
+            isWished = isWished,
+            maleAdditionalPrice = maleAdditionalPrice,
+            femaleAdditionalPrice = femaleAdditionalPrice,
         )
     }
 

--- a/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/product/dto/ProductDtos.kt
@@ -127,6 +127,18 @@ data class ProductDetailResponse(
     val pickUpDeliveryFee: BigDecimal?,
 
     @Schema(
+        description = "수컷 추가 가격 (null인 경우 지원 X)",
+        example = "0"
+    )
+    val maleAdditionalPrice: BigDecimal?,
+
+    @Schema(
+        description = "암컷 추가 가격 (null인 경우 지원 X)",
+        example = "2000"
+    )
+    val femaleAdditionalPrice: BigDecimal?,
+
+    @Schema(
         description = "사육 온도 최소",
         example = "10"
     )
@@ -157,12 +169,6 @@ data class ProductDetailResponse(
     val temperament: String,
 
     @Schema(
-        description = "암/수 성별을 갖는지 여부",
-        example = "true"
-    )
-    val hasDistinctSex: Boolean,
-
-    @Schema(
         description = "찜 여부",
         example = "true"
     )
@@ -173,6 +179,8 @@ data class ProductDetailResponse(
         imageUrls: List<String>,
         descriptionImageUrls: List<String>,
         isWished: Boolean,
+        maleAdditionalPrice: BigDecimal?,
+        femaleAdditionalPrice: BigDecimal?,
     ) : this(
         id = productWithInfoResponse.id,
         name = productWithInfoResponse.name,
@@ -192,12 +200,13 @@ data class ProductDetailResponse(
         safeDeliveryFee = productWithInfoResponse.safeDeliveryFee,
         commonDeliveryFee = productWithInfoResponse.commonDeliveryFee,
         pickUpDeliveryFee = productWithInfoResponse.pickUpDeliveryFee,
+        maleAdditionalPrice = maleAdditionalPrice,
+        femaleAdditionalPrice = femaleAdditionalPrice,
         optimalTemperatureMin = productWithInfoResponse.optimalTemperatureMin,
         optimalTemperatureMax = productWithInfoResponse.optimalTemperatureMax,
         difficultyLevel = productWithInfoResponse.difficultyLevel,
         optimalTankSize = productWithInfoResponse.optimalTankSize,
         temperament = productWithInfoResponse.temperament,
-        hasDistinctSex = productWithInfoResponse.hasDistinctSex,
         isWished = isWished,
     )
 }

--- a/src/main/kotlin/com/petqua/common/util/BigDecimalUtils.kt
+++ b/src/main/kotlin/com/petqua/common/util/BigDecimalUtils.kt
@@ -1,0 +1,9 @@
+package com.petqua.common.util
+
+import java.math.BigDecimal
+
+const val DEFAULT_SCALE = 2
+
+fun BigDecimal.setDefaultScale(): BigDecimal {
+    return this.setScale(DEFAULT_SCALE)
+}

--- a/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProduct.kt
@@ -3,6 +3,7 @@ package com.petqua.domain.cart
 import com.petqua.common.domain.BaseEntity
 import com.petqua.common.util.throwExceptionWhen
 import com.petqua.domain.delivery.DeliveryMethod
+import com.petqua.domain.product.option.Sex
 import com.petqua.exception.cart.CartProductException
 import com.petqua.exception.cart.CartProductExceptionType.FORBIDDEN_CART_PRODUCT
 import jakarta.persistence.AttributeOverride
@@ -14,6 +15,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import java.math.BigDecimal
 
 @Entity
 class CartProduct(
@@ -31,11 +33,14 @@ class CartProduct(
     var quantity: CartProductQuantity,
 
     @Column(nullable = false)
-    var isMale: Boolean,
+    var sex: Sex,
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     var deliveryMethod: DeliveryMethod,
+
+    @Column(nullable = false)
+    var deliveryFee: BigDecimal,
 ) : BaseEntity() {
 
     fun validateOwner(accessMemberId: Long) {
@@ -44,11 +49,13 @@ class CartProduct(
 
     fun updateOptions(
         quantity: CartProductQuantity,
-        isMale: Boolean,
+        sex: Sex,
         deliveryMethod: DeliveryMethod,
+        deliveryFee: BigDecimal,
     ) {
         this.quantity = quantity
-        this.isMale = isMale
+        this.sex = sex
         this.deliveryMethod = deliveryMethod
+        this.deliveryFee = deliveryFee
     }
 }

--- a/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/cart/CartProductRepository.kt
@@ -1,14 +1,15 @@
 package com.petqua.domain.cart
 
 import com.petqua.domain.delivery.DeliveryMethod
+import com.petqua.domain.product.option.Sex
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CartProductRepository : JpaRepository<CartProduct, Long>, CartProductCustomRepository {
 
-    fun findByMemberIdAndProductIdAndIsMaleAndDeliveryMethod(
+    fun findByMemberIdAndProductIdAndSexAndDeliveryMethod(
         memberId: Long,
         productId: Long,
-        isMale: Boolean,
+        sex: Sex,
         deliveryMethod: DeliveryMethod
     ): CartProduct?
 

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -19,7 +19,6 @@ import com.petqua.domain.product.dto.ProductReadCondition
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
 import com.petqua.domain.product.dto.ProductWithInfoResponse
-import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.store.Store
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
@@ -49,14 +48,12 @@ class ProductCustomRepositoryImpl(
                 ),
                 entity(ProductInfo::class),
                 entity(Category::class),
-                entity(ProductOption::class),
             ).from(
                 entity(Product::class),
                 join(Store::class).on(path(Product::storeId).eq(path(Store::id))),
                 leftJoin(ProductDescription::class).on(path(Product::productDescriptionId).eq(path(ProductDescription::id))),
                 join(ProductInfo::class).on(path(Product::productInfoId).eq(path(ProductInfo::id))),
                 join(Category::class).on(path(Product::categoryId).eq(path(Category::id))),
-                join(ProductOption::class).on(path(Product::id).eq(path(ProductOption::productId)))
             ).whereAnd(
                 path(Product::id).eq(id),
                 active(),

--- a/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/petqua/domain/product/dto/ProductDtos.kt
@@ -7,7 +7,6 @@ import com.petqua.domain.product.ProductSourceType
 import com.petqua.domain.product.Sorter
 import com.petqua.domain.product.category.Category
 import com.petqua.domain.product.detail.info.ProductInfo
-import com.petqua.domain.product.option.ProductOption
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -82,7 +81,6 @@ data class ProductWithInfoResponse(
     val difficultyLevel: String,
     val optimalTankSize: String,
     val temperament: String,
-    val hasDistinctSex: Boolean,
 ) {
     constructor(
         product: Product,
@@ -90,7 +88,6 @@ data class ProductWithInfoResponse(
         productDescription: ProductDescriptionResponse,
         productInfo: ProductInfo,
         category: Category,
-        productOption: ProductOption,
     ) : this(
         id = product.id,
         name = product.name,
@@ -114,7 +111,6 @@ data class ProductWithInfoResponse(
         difficultyLevel = productInfo.difficultyLevel.description,
         optimalTankSize = productInfo.optimalTankSize.description,
         temperament = productInfo.temperament.description,
-        hasDistinctSex = productOption.hasDistinctSex(),
     )
 }
 

--- a/src/main/kotlin/com/petqua/domain/product/option/ProductOptionRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/option/ProductOptionRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductOptionRepository : JpaRepository<ProductOption, Long> {
     fun findByProductIdIn(productIds: List<Long>): Set<ProductOption>
+    fun existsByProductIdAndSex(productId: Long, sex: Sex): Boolean
 }

--- a/src/main/kotlin/com/petqua/domain/product/option/ProductOptionRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/product/option/ProductOptionRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ProductOptionRepository : JpaRepository<ProductOption, Long> {
     fun findByProductIdIn(productIds: List<Long>): Set<ProductOption>
     fun existsByProductIdAndSex(productId: Long, sex: Sex): Boolean
+    fun findAllByProductId(productId: Long): List<ProductOption>
 }

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -13,6 +13,7 @@ enum class CartProductExceptionType(
 ) : BaseExceptionType {
 
     NOT_FOUND_CART_PRODUCT(httpStatus = NOT_FOUND, code = "CP01", errorMessage = "존재 하지 않는 봉달 상품입니다."),
+    NOT_EXIST_OPTION(httpStatus = BAD_REQUEST, code = "CP02", errorMessage = "존재 하지 않는 상품 옵션입니다."),
 
     INVALID_DELIVERY_METHOD(httpStatus = BAD_REQUEST, code = "CP10", errorMessage = "유효하지 않는 배송 방법입니다."),
 

--- a/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/cart/CartProductExceptionType.kt
@@ -21,6 +21,8 @@ enum class CartProductExceptionType(
 
     DUPLICATED_PRODUCT(httpStatus = BAD_REQUEST, code = "CP30", errorMessage = "이미 봉달 목록에 담긴 상품입니다."),
     FORBIDDEN_CART_PRODUCT(httpStatus = FORBIDDEN, code = "CP31", errorMessage = "해당 봉달 상품에 대한 권한이 없습니다."),
+
+    DIFFERENT_DELIVERY_FEE(httpStatus = BAD_REQUEST, code = "CP40", errorMessage = "잘못된 배송비입니다."),
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -3,7 +3,6 @@ package com.petqua.presentation.cart
 import com.petqua.application.cart.CartProductService
 import com.petqua.application.cart.dto.CartProductWithSupportedOptionResponse
 import com.petqua.application.cart.dto.DeleteCartProductCommand
-import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
@@ -39,7 +38,7 @@ class CartProductController(
     fun save(
         @Auth loginMember: LoginMember,
         @RequestBody request: SaveCartProductRequest
-    ): ResponseEntity<ProductDetailResponse> {
+    ): ResponseEntity<Void> {
         val command = request.toCommand(loginMember.memberId)
         val cartProductId = cartProductService.save(command)
         val location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/CartProductController.kt
@@ -1,7 +1,7 @@
 package com.petqua.presentation.cart
 
 import com.petqua.application.cart.CartProductService
-import com.petqua.application.cart.dto.CartProductResponse
+import com.petqua.application.cart.dto.CartProductWithSupportedOptionResponse
 import com.petqua.application.cart.dto.DeleteCartProductCommand
 import com.petqua.application.product.dto.ProductDetailResponse
 import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
@@ -83,7 +83,7 @@ class CartProductController(
     @GetMapping
     fun readAll(
         @Auth loginMember: LoginMember,
-    ): ResponseEntity<List<CartProductResponse>> {
+    ): ResponseEntity<List<CartProductWithSupportedOptionResponse>> {
         val responses = cartProductService.readAll(loginMember.memberId)
         return ResponseEntity.ok(responses)
     }

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -4,7 +4,9 @@ import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
+import com.petqua.domain.product.option.Sex
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 
 data class SaveCartProductRequest(
     @Schema(
@@ -20,11 +22,11 @@ data class SaveCartProductRequest(
     val quantity: Int,
 
     @Schema(
-        description = "수컷 여부",
-        example = "true",
-        allowableValues = ["true", "false"]
+        description = "성별",
+        example = "MALE",
+        allowableValues = ["MALE", "FEMALE", "HERMAPHRODITE"]
     )
-    val isMale: Boolean,
+    val sex: Sex,
 
     @Schema(
         description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
@@ -32,6 +34,12 @@ data class SaveCartProductRequest(
         allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
     )
     val deliveryMethod: String,
+
+    @Schema(
+        description = "배송비",
+        example = "3000"
+    )
+    val deliveryFee: BigDecimal,
 ) {
 
     fun toCommand(memberId: Long): SaveCartProductCommand {
@@ -39,8 +47,9 @@ data class SaveCartProductRequest(
             memberId = memberId,
             productId = productId,
             quantity = quantity,
-            isMale = isMale,
-            deliveryMethod = DeliveryMethod.from(deliveryMethod)
+            sex = sex,
+            deliveryMethod = DeliveryMethod.from(deliveryMethod),
+            deliveryFee = deliveryFee,
         )
     }
 }
@@ -53,11 +62,11 @@ data class UpdateCartProductOptionRequest(
     val quantity: Int,
 
     @Schema(
-        description = "수컷 여부",
-        example = "true",
-        allowableValues = ["true", "false"]
+        description = "성별",
+        example = "MALE",
+        allowableValues = ["MALE", "FEMALE", "HERMAPHRODITE"]
     )
-    val isMale: Boolean,
+    val sex: Sex,
 
     @Schema(
         description = "배송 방법(\"COMMON : 일반\", \"SAFETY : 안전\", \"PICK_UP : 직접\")",
@@ -65,6 +74,12 @@ data class UpdateCartProductOptionRequest(
         allowableValues = ["COMMON", "SAFETY", "PICK_UP"]
     )
     val deliveryMethod: String,
+
+    @Schema(
+        description = "배송비",
+        example = "3000"
+    )
+    val deliveryFee: BigDecimal,
 ) {
 
     fun toCommand(memberId: Long, cartProductId: Long): UpdateCartProductOptionCommand {
@@ -72,8 +87,9 @@ data class UpdateCartProductOptionRequest(
             memberId = memberId,
             cartProductId = cartProductId,
             quantity = CartProductQuantity(quantity),
-            isMale = isMale,
-            deliveryMethod = DeliveryMethod.from(deliveryMethod)
+            sex = sex,
+            deliveryMethod = DeliveryMethod.from(deliveryMethod),
+            deliveryFee = deliveryFee,
         )
     }
 }

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -26,6 +26,7 @@ import com.petqua.domain.product.detail.info.ProductInfoRepository
 import com.petqua.domain.product.detail.info.Temperament
 import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.product.option.Sex.FEMALE
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.domain.store.StoreRepository
 import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
@@ -45,7 +46,7 @@ import com.petqua.test.fixture.wishProduct
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigDecimal
+import java.math.BigDecimal.ZERO
 import kotlin.Long.Companion.MIN_VALUE
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
@@ -97,17 +98,25 @@ class ProductServiceTest(
                 name = "고정구피",
                 storeId = store.id,
                 categoryId = category.id,
-                discountPrice = BigDecimal.ZERO,
+                discountPrice = ZERO,
                 reviewCount = 0,
                 reviewTotalScore = 0,
                 productDescriptionId = productDescription.id,
                 productInfoId = productInfo.id,
             )
         )
-        val productOption = productOptionRepository.save(
+        productOptionRepository.save(
+            productOption(
+                productId = product.id,
+                sex = MALE,
+                additionalPrice = ZERO,
+            )
+        )
+        productOptionRepository.save(
             productOption(
                 productId = product.id,
                 sex = FEMALE,
+                additionalPrice = 2000.toBigDecimal(),
             )
         )
         val productImage = productImageRepository.save(
@@ -146,7 +155,7 @@ class ProductServiceTest(
                     descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                     productInfo = productInfo,
                     category = category,
-                    hasDistinctSex = productOption.hasDistinctSex(),
+                    femaleAdditionalPrice = 2000.toBigDecimal(),
                     isWished = true
                 )
             }
@@ -181,7 +190,7 @@ class ProductServiceTest(
                     descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                     productInfo = productInfo,
                     category = category,
-                    hasDistinctSex = productOption.hasDistinctSex(),
+                    femaleAdditionalPrice = 2000.toBigDecimal(),
                     isWished = false
                 )
             }

--- a/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
+++ b/src/test/kotlin/com/petqua/domain/cart/CartProductTest.kt
@@ -1,6 +1,8 @@
 package com.petqua.domain.cart
 
 import com.petqua.domain.delivery.DeliveryMethod
+import com.petqua.domain.product.option.Sex.FEMALE
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.exception.cart.CartProductException
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
@@ -14,18 +16,20 @@ class CartProductTest : StringSpec({
             memberId = 1L,
             productId = 1L,
             quantity = CartProductQuantity(5),
-            isMale = true,
+            sex = FEMALE,
             deliveryMethod = DeliveryMethod.COMMON,
+            deliveryFee = 3000.toBigDecimal(),
         )
 
         cartProduct.updateOptions(
             quantity = CartProductQuantity(10),
-            isMale = false,
+            sex = MALE,
             deliveryMethod = DeliveryMethod.COMMON,
+            deliveryFee = 3000.toBigDecimal(),
         )
 
         assertSoftly(cartProduct) {
-            isMale shouldBe false
+            sex shouldBe MALE
             quantity.value shouldBe 10
             deliveryMethod shouldBe DeliveryMethod.COMMON
         }
@@ -36,8 +40,9 @@ class CartProductTest : StringSpec({
             memberId = 1L,
             productId = 1L,
             quantity = CartProductQuantity(5),
-            isMale = true,
+            sex = MALE,
             deliveryMethod = DeliveryMethod.COMMON,
+            deliveryFee = 3000.toBigDecimal(),
         )
 
         shouldThrow<CartProductException> {

--- a/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/product/ProductCustomRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.dto.ProductSearchCondition
 import com.petqua.domain.product.dto.ProductWithInfoResponse
 import com.petqua.domain.product.option.ProductOptionRepository
-import com.petqua.domain.product.option.Sex
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.StoreRepository
 import com.petqua.exception.product.ProductException
@@ -114,16 +114,16 @@ class ProductCustomRepositoryImplTest(
                 productInfoId = productInfo2.id,
             )
         )
-        val productOption1 = productOptionRepository.save(
+        productOptionRepository.save(
             productOption(
                 productId = product1.id,
-                sex = Sex.MALE,
+                sex = MALE,
             )
         )
-        val productOption2 = productOptionRepository.save(
+        productOptionRepository.save(
             productOption(
                 productId = product2.id,
-                sex = Sex.MALE,
+                sex = MALE,
             )
         )
 
@@ -142,7 +142,6 @@ class ProductCustomRepositoryImplTest(
                     ),
                     productInfo = productInfo1,
                     category = category,
-                    productOption = productOption1,
                 )
             }
         }
@@ -162,7 +161,6 @@ class ProductCustomRepositoryImplTest(
                     ),
                     productInfo = productInfo2,
                     category = category,
-                    productOption = productOption2,
                 )
             }
         }

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerSteps.kt
@@ -1,7 +1,9 @@
 package com.petqua.presentation.cart
 
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.presentation.cart.dto.SaveCartProductRequest
 import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
+import com.petqua.test.fixture.saveCartProductRequest
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -28,11 +30,12 @@ fun requestSaveCartProduct(
 }
 
 fun saveCartProductAndReturnId(accessToken: String, productId: Long = 1L): Long {
-    val sampleCartProduct = SaveCartProductRequest(
+    val sampleCartProduct = saveCartProductRequest(
         productId = productId,
         quantity = 1,
-        isMale = true,
-        deliveryMethod = "COMMON"
+        sex = MALE,
+        deliveryMethod = "COMMON",
+        deliveryFee = 3000.toBigDecimal(),
     )
     val response = requestSaveCartProduct(sampleCartProduct, accessToken)
     return parseCartProductIdFromLocationHeader(response)

--- a/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/product/ProductControllerTest.kt
@@ -26,7 +26,8 @@ import com.petqua.domain.product.detail.info.ProductInfoRepository
 import com.petqua.domain.product.detail.info.Temperament
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.option.ProductOptionRepository
-import com.petqua.domain.product.option.Sex.HERMAPHRODITE
+import com.petqua.domain.product.option.Sex.FEMALE
+import com.petqua.domain.product.option.Sex.MALE
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.StoreRepository
 import com.petqua.exception.product.ProductExceptionType.INVALID_SEARCH_WORD
@@ -110,10 +111,19 @@ class ProductControllerTest(
                     productInfoId = productInfo.id
                 )
             )
-            val productOption = productOptionRepository.save(
+            productOptionRepository.save(
                 productOption(
                     productId = product.id,
-                    sex = HERMAPHRODITE
+                    sex = MALE,
+                    additionalPrice = ZERO,
+                )
+            )
+
+            productOptionRepository.save(
+                productOption(
+                    productId = product.id,
+                    sex = FEMALE,
+                    additionalPrice = 2000.toBigDecimal(),
                 )
             )
             val productImage = productImageRepository.save(
@@ -157,7 +167,7 @@ class ProductControllerTest(
                             descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                             productInfo = productInfo,
                             category = category,
-                            hasDistinctSex = productOption.hasDistinctSex(),
+                            femaleAdditionalPrice = 2000.toBigDecimal(),
                             isWished = true
                         )
                     }
@@ -199,7 +209,7 @@ class ProductControllerTest(
                             descriptionImageUrls = listOf(productDescriptionImage.imageUrl),
                             productInfo = productInfo,
                             category = category,
-                            hasDistinctSex = productOption.hasDistinctSex(),
+                            femaleAdditionalPrice = 2000.toBigDecimal(),
                             isWished = false
                         )
                     }

--- a/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
@@ -2,6 +2,7 @@ package com.petqua.test.fixture
 
 import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
+import com.petqua.common.util.setDefaultScale
 import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
@@ -47,7 +48,7 @@ fun saveCartProductCommand(
         quantity = quantity,
         sex = sex,
         deliveryMethod = deliveryMethod,
-        deliveryFee = deliveryFee.setScale(2),
+        deliveryFee = deliveryFee.setDefaultScale(),
     )
 }
 
@@ -65,7 +66,7 @@ fun updateCartProductOptionCommand(
         quantity = CartProductQuantity(quantity),
         sex = sex,
         deliveryMethod = deliveryMethod,
-        deliveryFee = deliveryFee.setScale(2),
+        deliveryFee = deliveryFee.setDefaultScale(),
     )
 }
 
@@ -82,7 +83,7 @@ fun saveCartProductRequest(
         quantity = quantity,
         sex = sex,
         deliveryMethod = deliveryMethod,
-        deliveryFee = deliveryFee.setScale(2),
+        deliveryFee = deliveryFee.setDefaultScale(),
     )
 }
 
@@ -96,7 +97,7 @@ fun updateCartProductOptionRequest(
         quantity = quantity,
         sex = sex,
         deliveryMethod = deliveryMethod,
-        deliveryFee = deliveryFee.setScale(2),
+        deliveryFee = deliveryFee.setDefaultScale(),
     )
 }
 

--- a/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
@@ -1,23 +1,102 @@
 package com.petqua.test.fixture
 
+import com.petqua.application.cart.dto.SaveCartProductCommand
+import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
+import com.petqua.domain.delivery.DeliveryMethod.COMMON
+import com.petqua.domain.product.option.Sex
+import com.petqua.domain.product.option.Sex.MALE
+import com.petqua.presentation.cart.dto.SaveCartProductRequest
+import com.petqua.presentation.cart.dto.UpdateCartProductOptionRequest
+import java.math.BigDecimal
 
 fun cartProduct(
     id: Long = 0L,
     memberId: Long = 1L,
     productId: Long = 1L,
     quantity: Int = 1,
-    isMale: Boolean = true,
-    deliveryMethod: DeliveryMethod = DeliveryMethod.COMMON,
+    sex: Sex = MALE,
+    deliveryMethod: DeliveryMethod = COMMON,
+    deliveryFee: BigDecimal = 3000.toBigDecimal(),
 ): CartProduct {
     return CartProduct(
         id = id,
         memberId = memberId,
         productId = productId,
         quantity = CartProductQuantity(quantity),
-        isMale = isMale,
+        sex = sex,
         deliveryMethod = deliveryMethod,
+        deliveryFee = deliveryFee,
     )
 }
+
+// applications
+fun saveCartProductCommand(
+    memberId: Long = 0L,
+    productId: Long = 0L,
+    quantity: Int = 1,
+    sex: Sex = MALE,
+    deliveryMethod: DeliveryMethod = COMMON,
+    deliveryFee: BigDecimal = 3000.toBigDecimal(),
+): SaveCartProductCommand {
+    return SaveCartProductCommand(
+        memberId = memberId,
+        productId = productId,
+        quantity = quantity,
+        sex = sex,
+        deliveryMethod = deliveryMethod,
+        deliveryFee = deliveryFee.setScale(2),
+    )
+}
+
+fun updateCartProductOptionCommand(
+    memberId: Long = 0L,
+    cartProductId: Long = 0L,
+    quantity: Int = 1,
+    sex: Sex = MALE,
+    deliveryMethod: DeliveryMethod = COMMON,
+    deliveryFee: BigDecimal = 3000.toBigDecimal(),
+): UpdateCartProductOptionCommand {
+    return UpdateCartProductOptionCommand(
+        memberId = memberId,
+        cartProductId = cartProductId,
+        quantity = CartProductQuantity(quantity),
+        sex = sex,
+        deliveryMethod = deliveryMethod,
+        deliveryFee = deliveryFee.setScale(2),
+    )
+}
+
+// controller
+fun saveCartProductRequest(
+    productId: Long = 0L,
+    quantity: Int = 1,
+    sex: Sex = MALE,
+    deliveryMethod: String = "COMMON",
+    deliveryFee: BigDecimal = 3000.toBigDecimal(),
+): SaveCartProductRequest {
+    return SaveCartProductRequest(
+        productId = productId,
+        quantity = quantity,
+        sex = sex,
+        deliveryMethod = deliveryMethod,
+        deliveryFee = deliveryFee.setScale(2),
+    )
+}
+
+fun updateCartProductOptionRequest(
+    quantity: Int = 1,
+    sex: Sex = MALE,
+    deliveryMethod: String = "COMMON",
+    deliveryFee: BigDecimal = 3000.toBigDecimal(),
+): UpdateCartProductOptionRequest {
+    return UpdateCartProductOptionRequest(
+        quantity = quantity,
+        sex = sex,
+        deliveryMethod = deliveryMethod,
+        deliveryFee = deliveryFee.setScale(2),
+    )
+}
+

--- a/src/test/kotlin/com/petqua/test/fixture/OrderFixture.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/OrderFixture.kt
@@ -2,6 +2,7 @@ package com.petqua.test.fixture
 
 import com.petqua.application.order.dto.OrderProductCommand
 import com.petqua.application.order.dto.SaveOrderCommand
+import com.petqua.common.util.setDefaultScale
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.delivery.DeliveryMethod.COMMON
 import com.petqua.domain.product.option.Sex
@@ -9,8 +10,6 @@ import com.petqua.domain.product.option.Sex.FEMALE
 import java.math.BigDecimal
 import java.math.BigDecimal.ONE
 import java.math.BigDecimal.ZERO
-
-private const val DEFAULT_SCALE = 2
 
 fun saveOrderCommand(
     memberId: Long = 0L,
@@ -24,7 +23,7 @@ fun saveOrderCommand(
         shippingAddressId = shippingAddressId,
         shippingRequest = shippingRequest,
         orderProductCommands = orderProductCommands,
-        totalAmount = totalAmount.setScale(DEFAULT_SCALE),
+        totalAmount = totalAmount.setDefaultScale(),
     )
 }
 
@@ -43,13 +42,13 @@ fun orderProductCommand(
     return OrderProductCommand(
         productId = productId,
         quantity = quantity,
-        originalPrice = originalPrice.setScale(DEFAULT_SCALE),
+        originalPrice = originalPrice.setDefaultScale(),
         discountRate = discountRate,
-        discountPrice = discountPrice.setScale(DEFAULT_SCALE),
-        orderPrice = orderPrice.setScale(DEFAULT_SCALE),
+        discountPrice = discountPrice.setDefaultScale(),
+        orderPrice = orderPrice.setDefaultScale(),
         sex = sex,
-        additionalPrice = additionalPrice.setScale(DEFAULT_SCALE),
-        deliveryFee = deliveryFee.setScale(DEFAULT_SCALE),
+        additionalPrice = additionalPrice.setDefaultScale(),
+        deliveryFee = deliveryFee.setDefaultScale(),
         deliveryMethod = deliveryMethod,
     )
 }

--- a/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
@@ -1,6 +1,7 @@
 package com.petqua.test.fixture
 
 import com.petqua.application.product.dto.ProductDetailResponse
+import com.petqua.common.util.setDefaultScale
 import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.product.Product
 import com.petqua.domain.product.WishCount
@@ -19,8 +20,6 @@ import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.product.option.Sex
 import java.math.BigDecimal
-
-private const val DEFAULT_SCALE = 2
 
 fun product(
     id: Long = 0L,
@@ -45,18 +44,18 @@ fun product(
         id = id,
         name = name,
         categoryId = categoryId,
-        price = price.setScale(DEFAULT_SCALE),
+        price = price.setDefaultScale(),
         storeId = storeId,
         discountRate = discountRate,
-        discountPrice = discountPrice.setScale(DEFAULT_SCALE),
+        discountPrice = discountPrice.setDefaultScale(),
         wishCount = WishCount(wishCount),
         reviewCount = reviewCount,
         reviewTotalScore = reviewTotalScore,
         thumbnailUrl = thumbnailUrl,
         isDeleted = isDeleted,
-        safeDeliveryFee = safeDeliveryFee?.setScale(DEFAULT_SCALE),
-        commonDeliveryFee = commonDeliveryFee?.setScale(DEFAULT_SCALE),
-        pickUpDeliveryFee = pickUpDeliveryFee?.setScale(DEFAULT_SCALE),
+        safeDeliveryFee = safeDeliveryFee?.setDefaultScale(),
+        commonDeliveryFee = commonDeliveryFee?.setDefaultScale(),
+        pickUpDeliveryFee = pickUpDeliveryFee?.setDefaultScale(),
         productDescriptionId = productDescriptionId,
         productInfoId = productInfoId
     )

--- a/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/ProductFixtures.kt
@@ -139,7 +139,8 @@ fun productDetailResponse(
     descriptionImageUrls: List<String>,
     productInfo: ProductInfo,
     category: Category,
-    hasDistinctSex: Boolean,
+    maleAdditionalPrice: BigDecimal? = BigDecimal.ZERO,
+    femaleAdditionalPrice: BigDecimal? = BigDecimal.ZERO,
     isWished: Boolean,
 ): ProductDetailResponse {
     return ProductDetailResponse(
@@ -161,12 +162,13 @@ fun productDetailResponse(
         safeDeliveryFee = product.safeDeliveryFee,
         commonDeliveryFee = product.commonDeliveryFee,
         pickUpDeliveryFee = product.pickUpDeliveryFee,
+        maleAdditionalPrice = maleAdditionalPrice?.setScale(2),
+        femaleAdditionalPrice = femaleAdditionalPrice?.setScale(2),
         optimalTemperatureMin = productInfo.optimalTemperature.optimalTemperatureMin,
         optimalTemperatureMax = productInfo.optimalTemperature.optimalTemperatureMax,
         difficultyLevel = productInfo.difficultyLevel.description,
         optimalTankSize = productInfo.optimalTankSize.description,
         temperament = productInfo.temperament.description,
-        hasDistinctSex = hasDistinctSex,
         isWished = isWished,
     )
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #102 

### 📁 작업 설명
- 설명
봉달 목록 관련하여 응답 데이터를 수정하였습니다.

AS-IS
```json
{
    "id": 3,
    "storeName": "store",
    "productId": 3,
    "productName": "쿠아3",
    "productThumbnailUrl": "image.jpg",
    "productPrice": 1,
    "productDiscountRate": 0,
    "productDiscountPrice": 1,
    "quantity": 1,
    "isMale": true,
    "deliveryMethod": "COMMON",
    "isOnSale": true
},
```

TO-BE
```json
{
    "id": 3,
    "storeName": "store",
    "productId": 3,
    "productName": "쿠아3",
    "productThumbnailUrl": "image.jpg",
    "productPrice": 1,
    "productDiscountRate": 0,
    "productDiscountPrice": 1,
    "quantity": 1,
    "sex": "MALE",
    "deliveryMethod": "COMMON",
    "deliveryFee": 3000.00,
    "isOnSale": true,
    "safeDeliveryFee": null,
    "commonDeliveryFee": 3000.00,
    "pickUpDeliveryFee": null,
    "maleAdditionalPrice": 0.00,
    "femaleAdditionalPrice": 3000.00
},
```
성별이 단순 boolean이 아닌 Enum으로 변경됨에 따라 필드값이 수정 되었습니다.
승훈님과 논의 후, 봉달 목록에서 옵션 변경 시 지원되는 옵션(성별, 운송 정보)을 표현하기 위해 [safeDeliveryFee, commonDeliveryFee, maleAdditionalPrice] 등이 추가 되었습니다.
운송방식과 동일하게 `maleAdditionalPrice`가 null인 경우 지원하지 않는 것으로 간주합니다.

### 기타
자웅동체인 경우 maleAdditionalPrice과 femaleAdditionalPrice 모두 null 값이 응답됩니다.
성별 옵션 선택이 존재하지 않기 때문에 추가금액 역시 의미없는 값이라 생각했습니다. (상품 가격만으로도 표현 가능)
