### PR TITLE
infra: redis 캐싱 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,10 @@ dependencies {
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("io.rest-assured:rest-assured:5.3.1")
     testImplementation("io.rest-assured:kotlin-extensions:5.3.1")
+
+    // testcontainers
+    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:5.4.2")
+//    testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,8 +70,7 @@ dependencies {
     testImplementation("io.rest-assured:kotlin-extensions:5.3.1")
 
     // testcontainers
-    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:5.4.2")
-//    testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
+    testImplementation("org.testcontainers:testcontainers")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    // spring data jpa
+    // spring data
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     // spring boot web
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/src/main/kotlin/com/petqua/application/announcement/AnnouncementDtos.kt
+++ b/src/main/kotlin/com/petqua/application/announcement/AnnouncementDtos.kt
@@ -1,5 +1,6 @@
 package com.petqua.application.announcement
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.petqua.domain.announcement.Announcement
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -8,18 +9,21 @@ data class AnnouncementResponse(
         description = "배너 id",
         example = "1"
     )
+    @JsonProperty("id")
     val id: Long,
 
     @Schema(
         description = "공지 제목",
         example = "[공지] 펫쿠아 안전 운송 시작"
     )
+    @JsonProperty("title")
     val title: String,
 
     @Schema(
         description = "링크 URL",
         example = "link.com"
     )
+    @JsonProperty("linkUrl")
     val linkUrl: String,
 ) {
     companion object {

--- a/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
+++ b/src/main/kotlin/com/petqua/application/banner/dto/BannerDtos.kt
@@ -1,5 +1,6 @@
 package com.petqua.application.banner.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.petqua.domain.banner.Banner
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -8,18 +9,21 @@ data class BannerResponse(
         description = "배너 id",
         example = "1"
     )
+    @JsonProperty("id")
     val id: Long,
 
     @Schema(
         description = "이미지 URL",
         example = "image.jpeg"
     )
+    @JsonProperty("imageUrl")
     val imageUrl: String,
 
     @Schema(
         description = "링크 URL",
         example = "link.com"
     )
+    @JsonProperty("linkUrl")
     val linkUrl: String,
 ) {
     companion object {

--- a/src/main/kotlin/com/petqua/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/CacheConfig.kt
@@ -20,7 +20,7 @@ class CacheConfig {
     @Bean
     fun cacheManager(redisConnectionFactory: LettuceConnectionFactory): CacheManager {
         val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(30))
+            .entryTtl(Duration.ofMinutes(10))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(

--- a/src/main/kotlin/com/petqua/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/CacheConfig.kt
@@ -1,10 +1,16 @@
 package com.petqua.common.config
 
+import java.time.Duration
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
 
 
 @EnableCaching
@@ -12,9 +18,20 @@ import org.springframework.context.annotation.Configuration
 class CacheConfig {
 
     @Bean
-    fun cacheManager(): CacheManager {
-        val cacheManager = ConcurrentMapCacheManager()
-        cacheManager.setCacheNames(listOf("banners", "announcements"))
-        return cacheManager
+    fun cacheManager(redisConnectionFactory: LettuceConnectionFactory): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .transactionAware()
+            .build()
     }
 }

--- a/src/main/kotlin/com/petqua/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/RedisConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 
@@ -25,10 +26,10 @@ class RedisConfig(
     }
 
     @Bean
-    fun redisTemplate(): RedisTemplate<String, *> {
-        val template = RedisTemplate<String, ByteArray>()
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
         template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = StringRedisSerializer()
+        template.valueSerializer = GenericJackson2JsonRedisSerializer()
         template.connectionFactory = redisConnectionFactory()
         return template
     }

--- a/src/main/kotlin/com/petqua/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/petqua/common/config/RedisConfig.kt
@@ -1,0 +1,35 @@
+package com.petqua.common.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+data class RedisProperties(
+    val host: String,
+    val port: Int,
+)
+
+@Configuration
+class RedisConfig(
+    private val redisProperties: RedisProperties
+) {
+
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        return LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, *> {
+        val template = RedisTemplate<String, ByteArray>()
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
+        template.connectionFactory = redisConnectionFactory()
+        return template
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -22,6 +22,7 @@ import com.petqua.domain.product.dto.ProductWithInfoResponse
 import com.petqua.domain.product.option.ProductOption
 import com.petqua.domain.store.Store
 import jakarta.persistence.EntityManager
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Repository
 
 private const val ESCAPE_LETTER = '\\'
@@ -150,6 +151,10 @@ class ProductCustomRepositoryImpl(
         )
     }
 
+    @Cacheable(
+        key = "'countByReadCondition' + #condition.hashCode()",
+        value = ["productCountByReadCondition"]
+    )
     override fun countBySearchCondition(condition: ProductSearchCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {
             select(
@@ -201,6 +206,10 @@ class ProductCustomRepositoryImpl(
         )
     }
 
+    @Cacheable(
+        key = "'countByKeywordSearchCondition' + #condition.hashCode()",
+        value = ["productCountBySearchCondition"]
+    )
     override fun countByKeywordSearchCondition(condition: ProductSearchCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {
             select(

--- a/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/ProductCustomRepositoryImpl.kt
@@ -101,6 +101,10 @@ class ProductCustomRepositoryImpl(
         )
     }
 
+    @Cacheable(
+        key = "'countByReadCondition' + #condition.hashCode()",
+        value = ["productCountByReadCondition"]
+    )
     override fun countByReadCondition(condition: ProductReadCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {
             select(
@@ -152,8 +156,8 @@ class ProductCustomRepositoryImpl(
     }
 
     @Cacheable(
-        key = "'countByReadCondition' + #condition.hashCode()",
-        value = ["productCountByReadCondition"]
+        key = "'countBySearchCondition' + #condition.hashCode()",
+        value = ["productCountBySearchCondition"]
     )
     override fun countBySearchCondition(condition: ProductSearchCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {
@@ -208,7 +212,7 @@ class ProductCustomRepositoryImpl(
 
     @Cacheable(
         key = "'countByKeywordSearchCondition' + #condition.hashCode()",
-        value = ["productCountBySearchCondition"]
+        value = ["productCountByKeywordSearchCondition"]
     )
     override fun countByKeywordSearchCondition(condition: ProductSearchCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {

--- a/src/main/kotlin/com/petqua/domain/product/category/CategoryCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/product/category/CategoryCustomRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.petqua.domain.product.Sorter.ENROLLMENT_DATE_DESC
 import com.petqua.domain.product.dto.ProductResponse
 import com.petqua.domain.store.Store
 import jakarta.persistence.EntityManager
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -53,6 +54,10 @@ class CategoryCustomRepositoryImpl(
         )
     }
 
+    @Cacheable(
+        key = "'countProductsByCategoryCondition' + #condition.hashCode()",
+        value = ["categoryCountProductsByCategoryCondition"]
+    )
     override fun countProductsByCategoryCondition(condition: CategoryProductReadCondition): Int {
         val query = jpql(ProductDynamicJpqlGenerator) {
             select(

--- a/src/main/kotlin/com/petqua/domain/product/option/Sex.kt
+++ b/src/main/kotlin/com/petqua/domain/product/option/Sex.kt
@@ -13,10 +13,6 @@ enum class Sex(
     HERMAPHRODITE("자웅동체"),
     ;
 
-    fun isLogical(other: Sex): Boolean {
-        return this != HERMAPHRODITE
-    }
-
     companion object {
         fun from(name: String): Sex {
             return enumValues<Sex>().find { it.name == name.uppercase(Locale.ENGLISH) }

--- a/src/test/kotlin/com/petqua/application/announcement/AnnouncementServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/announcement/AnnouncementServiceTest.kt
@@ -2,6 +2,7 @@ package com.petqua.application.announcement
 
 import com.petqua.domain.announcement.Announcement
 import com.petqua.domain.announcement.AnnouncementRepository
+import com.petqua.test.DataCleaner
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito.atMost
@@ -15,8 +16,9 @@ import org.springframework.test.context.TestConstructor.AutowireMode.ALL
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest(webEnvironment = NONE)
 class AnnouncementServiceTest(
-    private var announcementService: AnnouncementService,
-    @SpyBean private var announcementRepository: AnnouncementRepository,
+    private val announcementService: AnnouncementService,
+    @SpyBean private val announcementRepository: AnnouncementRepository,
+    private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
     Given("공지사항 조회 테스트") {
@@ -43,5 +45,9 @@ class AnnouncementServiceTest(
                 verify(announcementRepository, atMost(1)).findAll()
             }
         }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
     }
 })

--- a/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/banner/BannerServiceTest.kt
@@ -2,6 +2,7 @@ package com.petqua.application.banner
 
 import com.petqua.domain.banner.Banner
 import com.petqua.domain.banner.BannerRepository
+import com.petqua.test.DataCleaner
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito.atMost
@@ -12,8 +13,9 @@ import org.springframework.boot.test.mock.mockito.SpyBean
 
 @SpringBootTest(webEnvironment = NONE)
 class BannerServiceTest(
-    private var bannerService: BannerService,
-    @SpyBean private var bannerRepository: BannerRepository,
+    private val bannerService: BannerService,
+    @SpyBean private val bannerRepository: BannerRepository,
+    private val dataCleaner: DataCleaner,
 ) : BehaviorSpec({
 
     Given("Banner 조회 테스트") {
@@ -40,5 +42,9 @@ class BannerServiceTest(
                 verify(bannerRepository, atMost(1)).findAll()
             }
         }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
     }
 })

--- a/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/product/ProductServiceTest.kt
@@ -211,6 +211,24 @@ class ProductServiceTest(
                 )
             )
 
+            val productsResponse1 = productService.readAll(
+                ProductReadQuery(
+                    sourceType = NONE,
+                    sorter = ENROLLMENT_DATE_DESC,
+                    limit = 2,
+                    loginMemberOrGuest = LoginMemberOrGuest.getMemberFrom(AccessTokenClaims(member.id, MEMBER))
+                )
+            )
+
+            val productsResponse2 = productService.readAll(
+                ProductReadQuery(
+                    sourceType = NONE,
+                    sorter = ENROLLMENT_DATE_DESC,
+                    limit = 2,
+                    loginMemberOrGuest = LoginMemberOrGuest.getMemberFrom(AccessTokenClaims(member.id, MEMBER))
+                )
+            )
+
             Then("상품의 찜 여부와 함께 상품 정보가 반환된다") {
                 productsResponse shouldBe ProductsResponse(
                     products = listOf(
@@ -228,6 +246,9 @@ class ProductServiceTest(
                     hasNextPage = false,
                     totalProductsCount = 2
                 )
+
+                productsResponse1.totalProductsCount shouldBe 2
+                productsResponse2.totalProductsCount shouldBe 2
             }
         }
 

--- a/src/test/kotlin/com/petqua/test/DataCleaner.kt
+++ b/src/test/kotlin/com/petqua/test/DataCleaner.kt
@@ -2,10 +2,11 @@ package com.petqua.test
 
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
+import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import javax.sql.DataSource
 
 private const val FIRST_COLUMN = 1
 private const val SHOW_TABLES_QUERY = "SHOW TABLES"
@@ -19,7 +20,10 @@ class DataCleaner(
     @PersistenceContext
     val entityManager: EntityManager,
 
-    val truncateQueries: MutableList<String> = mutableListOf()
+    val truncateQueries: MutableList<String> = mutableListOf(),
+
+    @Autowired
+    val cacheManager: CacheManager,
 ) {
 
     @Transactional
@@ -28,6 +32,7 @@ class DataCleaner(
             initialize()
         }
         truncateAllTables()
+        clearCache()
     }
 
     private fun initialize() {
@@ -43,5 +48,9 @@ class DataCleaner(
 
     private fun truncateAllTables() {
         truncateQueries.forEach { entityManager.createNativeQuery(it).executeUpdate() }
+    }
+
+    private fun clearCache() {
+        cacheManager.cacheNames.forEach { cacheManager.getCache(it)?.clear() }
     }
 }

--- a/src/test/kotlin/com/petqua/test/config/RedisContainer.kt
+++ b/src/test/kotlin/com/petqua/test/config/RedisContainer.kt
@@ -1,6 +1,0 @@
-package com.petqua.test.config
-
-@Target(AnnotationTarget.TYPE)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class RedisContainer {
-}

--- a/src/test/kotlin/com/petqua/test/config/RedisContainer.kt
+++ b/src/test/kotlin/com/petqua/test/config/RedisContainer.kt
@@ -1,0 +1,6 @@
+package com.petqua.test.config
+
+@Target(AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RedisContainer {
+}

--- a/src/test/kotlin/com/petqua/test/config/RedisContainerConfig.kt
+++ b/src/test/kotlin/com/petqua/test/config/RedisContainerConfig.kt
@@ -1,0 +1,8 @@
+package com.petqua.test.config
+
+
+class RedisContainerConfig() {
+
+    companion object {
+    }
+}

--- a/src/test/kotlin/com/petqua/test/config/RedisContainerConfig.kt
+++ b/src/test/kotlin/com/petqua/test/config/RedisContainerConfig.kt
@@ -1,8 +1,0 @@
-package com.petqua.test.config
-
-
-class RedisContainerConfig() {
-
-    companion object {
-    }
-}

--- a/src/test/kotlin/com/petqua/test/config/TestConfig.kt
+++ b/src/test/kotlin/com/petqua/test/config/TestConfig.kt
@@ -3,10 +3,10 @@ package com.petqua.test.config
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.IsolationMode
 import io.kotest.extensions.spring.SpringExtension
-import org.springframework.context.annotation.Configuration
+import org.springframework.boot.test.context.TestConfiguration
 import org.testcontainers.containers.GenericContainer
 
-@Configuration
+@TestConfiguration
 class TestConfig : AbstractProjectConfig() {
     override val isolationMode = IsolationMode.InstancePerLeaf
 

--- a/src/test/kotlin/com/petqua/test/config/TestConfig.kt
+++ b/src/test/kotlin/com/petqua/test/config/TestConfig.kt
@@ -4,10 +4,24 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.IsolationMode
 import io.kotest.extensions.spring.SpringExtension
 import org.springframework.context.annotation.Configuration
+import org.testcontainers.containers.GenericContainer
 
 @Configuration
 class TestConfig : AbstractProjectConfig() {
     override val isolationMode = IsolationMode.InstancePerLeaf
 
     override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        @JvmStatic
+        val container = GenericContainer<Nothing>("redis").apply {
+            withExposedPorts(6379)
+            start()
+        }
+
+        init {
+            System.setProperty("spring.data.redis.host", container.host)
+            System.setProperty("spring.data.redis.port", container.getMappedPort(6379).toString())
+        }
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,11 @@ spring:
     hibernate:
       ddl-auto: create
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #95 

### 📁 작업 설명
- Redis 추가
ElasticCache를 도입하여 production 환경에서 사용할 cache memory를 추가하였습니다.
기존 `ConcurrentHashMap`으로 구현된 기본 Spring cache 대신, Redis를 cache 메모리로 사용 하도록 변경 하였습니다. fe2836c51cf9a075ddc915469939b7251d3107ee

Kotlin에서 json 응답을 캐싱할 때, Json객체로 역직렬화를 하지 못하는 이슈가 있었습니다.
`@JsonProperty` 를 추가하여 이슈를 해결하였습니다. 7f01d0a9310364d8f2b027617716a0ae0beb8ad8

count 쿼리에 대한 캐싱도 적용 하였습니다. fd63b30ffd5fec8fd0640328fdec9f38a67d9644

로컬에서 테스트 실행 시, redis가 필요하여 testcontainer를 통해 구축 하였습니다.
테스트 실행 할 때, docker가 실행중이어야 합니다..!
