### PR TITLE
feature: 알림 조회 및 읽음 처리 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
+++ b/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
@@ -1,0 +1,22 @@
+package com.petqua.application.notification
+
+import com.petqua.application.notification.dto.ReadAllNotificationQuery
+import com.petqua.application.notification.dto.ReadAllNotificationResponse
+import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.notification.NotificationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class NotificationService(
+    val notificationRepository: NotificationRepository,
+    val memberRepository: MemberRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun readAllNotification(query: ReadAllNotificationQuery): ReadAllNotificationResponse {
+        val responses = notificationRepository.findAllByMemberId(query.memberId, query.toPaging())
+        return ReadAllNotificationResponse.of(responses, query.limit)
+    }
+}

--- a/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
+++ b/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
@@ -2,8 +2,11 @@ package com.petqua.application.notification
 
 import com.petqua.application.notification.dto.ReadAllNotificationQuery
 import com.petqua.application.notification.dto.ReadAllNotificationResponse
+import com.petqua.common.domain.findByIdOrThrow
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.notification.NotificationRepository
+import com.petqua.exception.notification.NotificationException
+import com.petqua.exception.notification.NotificationExceptionType.NOTIFICATION_NOT_FOUND
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
@@ -35,7 +38,11 @@ class NotificationService(
         key = "'countUnreadNotifications' + #memberId",
         value = ["countUnreadNotifications"]
     )
-    fun checkNotification(memberId: Long) {
-        // 사용자가 알림을 확인 했을 때, 읽지 않은 알림의 개수 캐싱을 지운다
+    fun checkNotification(memberId: Long, notificationId: Long) {
+        val notification = notificationRepository.findByIdOrThrow(notificationId) {
+            NotificationException(NOTIFICATION_NOT_FOUND)
+        }
+        notification.validateOwner(memberId)
+        notification.markAsRead()
     }
 }

--- a/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
+++ b/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
@@ -4,6 +4,8 @@ import com.petqua.application.notification.dto.ReadAllNotificationQuery
 import com.petqua.application.notification.dto.ReadAllNotificationResponse
 import com.petqua.domain.member.MemberRepository
 import com.petqua.domain.notification.NotificationRepository
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,5 +20,22 @@ class NotificationService(
     fun readAllNotification(query: ReadAllNotificationQuery): ReadAllNotificationResponse {
         val responses = notificationRepository.findAllByMemberId(query.memberId, query.toPaging())
         return ReadAllNotificationResponse.of(responses, query.limit)
+    }
+
+    @Cacheable(
+        key = "'countUnreadNotifications' + #memberId",
+        value = ["countUnreadNotifications"]
+    )
+    @Transactional(readOnly = true)
+    fun countUnreadNotifications(memberId: Long): Int {
+        return notificationRepository.countByMemberIdAndIsReadIsFalse(memberId)
+    }
+
+    @CacheEvict(
+        key = "'countUnreadNotifications' + #memberId",
+        value = ["countUnreadNotifications"]
+    )
+    fun checkNotification(memberId: Long) {
+        // 사용자가 알림을 확인 했을 때, 읽지 않은 알림의 개수 캐싱을 지운다
     }
 }

--- a/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
+++ b/src/main/kotlin/com/petqua/application/notification/NotificationService.kt
@@ -31,7 +31,7 @@ class NotificationService(
     )
     @Transactional(readOnly = true)
     fun countUnreadNotifications(memberId: Long): Int {
-        return notificationRepository.countByMemberIdAndIsReadIsFalse(memberId)
+        return notificationRepository.countByMemberIdAndIsReadFalse(memberId)
     }
 
     @CacheEvict(

--- a/src/main/kotlin/com/petqua/application/notification/dto/NotificationDtos.kt
+++ b/src/main/kotlin/com/petqua/application/notification/dto/NotificationDtos.kt
@@ -1,0 +1,55 @@
+package com.petqua.application.notification.dto
+
+import com.petqua.common.domain.dto.CursorBasedPaging
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.notification.Notification
+import java.time.LocalDateTime
+
+data class ReadAllNotificationResponse(
+    val notifications: List<NotificationResponse>,
+    val hasNextPage: Boolean,
+) {
+    companion object {
+        fun of(notificationResponses: List<NotificationResponse>, limit: Int): ReadAllNotificationResponse {
+            return if (notificationResponses.size > limit) {
+                ReadAllNotificationResponse(
+                    notificationResponses.dropLast(PADDING_FOR_HAS_NEXT_PAGE),
+                    hasNextPage = true,
+                )
+            } else {
+                ReadAllNotificationResponse(notificationResponses, hasNextPage = false)
+            }
+        }
+    }
+}
+
+data class NotificationResponse(
+    val id: Long,
+    val memberId: Long,
+    val title: String,
+    val content: String,
+    val isRead: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    constructor(notification: Notification) : this(
+        id = notification.id,
+        memberId = notification.memberId,
+        title = notification.title,
+        content = notification.content,
+        isRead = notification.isRead,
+        createdAt = notification.createdAt,
+    )
+}
+
+data class ReadAllNotificationQuery(
+    val memberId: Long,
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+    val limit: Int = PAGING_LIMIT_CEILING,
+) {
+
+    fun toPaging(): CursorBasedPaging {
+        return CursorBasedPaging.of(lastViewedId, limit)
+    }
+}

--- a/src/main/kotlin/com/petqua/application/notification/dto/NotificationDtos.kt
+++ b/src/main/kotlin/com/petqua/application/notification/dto/NotificationDtos.kt
@@ -5,10 +5,16 @@ import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
 import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
 import com.petqua.domain.notification.Notification
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class ReadAllNotificationResponse(
     val notifications: List<NotificationResponse>,
+
+    @Schema(
+        description = "다음 페이지 존재 여부",
+        example = "true"
+    )
     val hasNextPage: Boolean,
 ) {
     companion object {
@@ -26,11 +32,40 @@ data class ReadAllNotificationResponse(
 }
 
 data class NotificationResponse(
+    @Schema(
+        description = "알림 Id",
+        example = "1"
+    )
     val id: Long,
+
+    @Schema(
+        description = "회원 Id",
+        example = "1"
+    )
     val memberId: Long,
+
+    @Schema(
+        description = "알림 제목",
+        example = "알림 제목"
+    )
     val title: String,
+
+    @Schema(
+        description = "알림 내용",
+        example = "알림 내용"
+    )
     val content: String,
+
+    @Schema(
+        description = "알림 읽음 여부",
+        example = "false"
+    )
     val isRead: Boolean,
+
+    @Schema(
+        description = "알림 생성일",
+        example = "2024-03-07T00:04:21"
+    )
     val createdAt: LocalDateTime,
 ) {
     constructor(notification: Notification) : this(

--- a/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
+++ b/src/main/kotlin/com/petqua/common/config/DataInitializer.kt
@@ -9,6 +9,8 @@ import com.petqua.domain.keyword.ProductKeyword
 import com.petqua.domain.keyword.ProductKeywordRepository
 import com.petqua.domain.member.Member
 import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.notification.Notification
+import com.petqua.domain.notification.NotificationRepository
 import com.petqua.domain.order.ShippingAddress
 import com.petqua.domain.order.ShippingAddressRepository
 import com.petqua.domain.product.Product
@@ -48,14 +50,14 @@ import com.petqua.domain.recommendation.ProductRecommendation
 import com.petqua.domain.recommendation.ProductRecommendationRepository
 import com.petqua.domain.store.Store
 import com.petqua.domain.store.StoreRepository
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import kotlin.random.Random
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
-import java.time.LocalDateTime
-import kotlin.random.Random
 
 @Component
 @Profile("local", "prod")
@@ -76,6 +78,7 @@ class DataInitializer(
     private val productKeywordRepository: ProductKeywordRepository,
     private val productDescriptionRepository: ProductDescriptionRepository,
     private val shippingAddressRepository: ShippingAddressRepository,
+    private val notificationRepository: NotificationRepository,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
@@ -327,5 +330,17 @@ class DataInitializer(
             )
         }
         productReviewImageRepository.saveAll(productReviewImages)
+
+        // notification
+        notificationRepository.saveAll(
+            (1..10).map {
+                Notification(
+                    memberId = memberId,
+                    title = "알림$it",
+                    content = "알림$it 내용",
+                    isRead = it % 2 == 0,
+                )
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/petqua/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/Notification.kt
@@ -1,6 +1,9 @@
 package com.petqua.domain.notification
 
 import com.petqua.common.domain.BaseEntity
+import com.petqua.common.util.throwExceptionWhen
+import com.petqua.exception.notification.NotificationException
+import com.petqua.exception.notification.NotificationExceptionType.FORBIDDEN_NOTIFICATION
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -22,5 +25,14 @@ class Notification(
     val content: String,
 
     @Column(nullable = false)
-    val isRead: Boolean,
-) : BaseEntity()
+    var isRead: Boolean,
+) : BaseEntity() {
+
+    fun validateOwner(accessMemberId: Long) {
+        throwExceptionWhen(accessMemberId != this.memberId) { NotificationException(FORBIDDEN_NOTIFICATION) }
+    }
+
+    fun markAsRead() {
+        this.isRead = true
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/Notification.kt
@@ -1,0 +1,26 @@
+package com.petqua.domain.notification
+
+import com.petqua.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class Notification(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false)
+    val memberId: Long,
+
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(nullable = false)
+    val content: String,
+
+    @Column(nullable = false)
+    val isRead: Boolean,
+) : BaseEntity()

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationCustomRepository.kt
@@ -1,0 +1,9 @@
+package com.petqua.domain.notification
+
+import com.petqua.application.notification.dto.NotificationResponse
+import com.petqua.common.domain.dto.CursorBasedPaging
+
+interface NotificationCustomRepository {
+
+    fun findAllByMemberId(memberId: Long, paging: CursorBasedPaging): List<NotificationResponse>
+}

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationCustomRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package com.petqua.domain.notification
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.application.notification.dto.NotificationResponse
+import com.petqua.common.domain.dto.CursorBasedPaging
+import com.petqua.common.util.createQuery
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class NotificationCustomRepositoryImpl(
+    private val entityManager: EntityManager,
+    private val jpqlRenderContext: JpqlRenderContext,
+    private val jpqlRenderer: JpqlRenderer,
+) : NotificationCustomRepository {
+
+    override fun findAllByMemberId(memberId: Long, paging: CursorBasedPaging): List<NotificationResponse> {
+        val query = jpql(NotificationDynamicJpqlGenerator) {
+            selectNew<NotificationResponse>(
+                entity(Notification::class)
+            ).from(
+                entity(Notification::class),
+            ).whereAnd(
+                path(Notification::memberId).eq(memberId),
+                notificationIdLt(paging.lastViewedId),
+            ).orderBy(
+                path(Notification::createdAt).desc()
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer,
+            paging.limit
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationDynamicJpqlGenerator.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationDynamicJpqlGenerator.kt
@@ -1,0 +1,16 @@
+package com.petqua.domain.notification
+
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
+
+class NotificationDynamicJpqlGenerator : Jpql() {
+    companion object Constructor : JpqlDsl.Constructor<NotificationDynamicJpqlGenerator> {
+        override fun newInstance(): NotificationDynamicJpqlGenerator = NotificationDynamicJpqlGenerator()
+    }
+
+    fun Jpql.notificationIdLt(lastViewedId: Long?): Predicate? {
+        return lastViewedId?.let { path(Notification::id).lt(it) }
+    }
+}
+

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
@@ -2,5 +2,5 @@ package com.petqua.domain.notification
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface NotificationRepository : JpaRepository<Notification, Long> {
-}
+interface NotificationRepository : JpaRepository<Notification, Long>, NotificationCustomRepository
+

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
@@ -3,6 +3,5 @@ package com.petqua.domain.notification
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NotificationRepository : JpaRepository<Notification, Long>, NotificationCustomRepository {
-    fun countByMemberIdAndIsReadIsFalse(memberId: Long): Int
+    fun countByMemberIdAndIsReadFalse(memberId: Long): Int
 }
-

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
@@ -1,0 +1,6 @@
+package com.petqua.domain.notification
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationRepository : JpaRepository<Notification, Long> {
+}

--- a/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/notification/NotificationRepository.kt
@@ -2,5 +2,7 @@ package com.petqua.domain.notification
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface NotificationRepository : JpaRepository<Notification, Long>, NotificationCustomRepository
+interface NotificationRepository : JpaRepository<Notification, Long>, NotificationCustomRepository {
+    fun countByMemberIdAndIsReadIsFalse(memberId: Long): Int
+}
 

--- a/src/main/kotlin/com/petqua/exception/notification/NotificationException.kt
+++ b/src/main/kotlin/com/petqua/exception/notification/NotificationException.kt
@@ -1,0 +1,13 @@
+package com.petqua.exception.notification
+
+import com.petqua.common.exception.BaseException
+import com.petqua.common.exception.BaseExceptionType
+
+class NotificationException(
+    private val exceptionType: NotificationExceptionType,
+) : BaseException() {
+
+    override fun exceptionType(): BaseExceptionType {
+        return exceptionType
+    }
+}

--- a/src/main/kotlin/com/petqua/exception/notification/NotificationExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/notification/NotificationExceptionType.kt
@@ -1,0 +1,30 @@
+package com.petqua.exception.notification
+
+import com.petqua.common.exception.BaseExceptionType
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
+
+enum class NotificationExceptionType(
+    private val httpStatus: HttpStatus,
+    private val code: String,
+    private val errorMessage: String,
+) : BaseExceptionType {
+
+    NOTIFICATION_NOT_FOUND(BAD_REQUEST, "N01", "존재하지 않는 알림입니다."),
+
+    FORBIDDEN_NOTIFICATION(FORBIDDEN, "N10", "알림에 대한 권한이 없습니다.")
+    ;
+
+    override fun httpStatus(): HttpStatus {
+        return httpStatus
+    }
+
+    override fun code(): String {
+        return code
+    }
+
+    override fun errorMessage(): String {
+        return errorMessage
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
+++ b/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
@@ -8,7 +8,10 @@ import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.notification.dto.ReadAllNotificationRequest
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -34,5 +37,14 @@ class NotificationController(
         @Auth loginMember: LoginMember,
     ): Int {
         return notificationService.countUnreadNotifications(loginMember.memberId)
+    }
+
+    @PatchMapping("/{notificationId}/check")
+    fun check(
+        @Auth loginMember: LoginMember,
+        @PathVariable notificationId: Long,
+    ): ResponseEntity<Unit> {
+        notificationService.checkNotification(loginMember.memberId, notificationId)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
+++ b/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
 @RequestMapping("/notifications")
 @Tag(name = "Notification", description = "알림 관련 API 명세")
 @RestController
@@ -19,7 +20,6 @@ class NotificationController(
     private val notificationService: NotificationService,
 ) {
 
-    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @GetMapping
     fun readAll(
         @Auth loginMember: LoginMember,
@@ -27,5 +27,12 @@ class NotificationController(
     ): ReadAllNotificationResponse {
         val query = request.toQuery(loginMember.memberId)
         return notificationService.readAllNotification(query)
+    }
+
+    @GetMapping("/unread/count")
+    fun countUnread(
+        @Auth loginMember: LoginMember,
+    ): Int {
+        return notificationService.countUnreadNotifications(loginMember.memberId)
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
+++ b/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
@@ -1,0 +1,31 @@
+package com.petqua.presentation.notification
+
+import com.petqua.application.notification.NotificationService
+import com.petqua.application.notification.dto.ReadAllNotificationResponse
+import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
+import com.petqua.domain.auth.Auth
+import com.petqua.domain.auth.LoginMember
+import com.petqua.presentation.notification.dto.ReadAllNotificationRequest
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/notifications")
+@Tag(name = "Notification", description = "알림 관련 API 명세")
+@RestController
+class NotificationController(
+    private val notificationService: NotificationService,
+) {
+
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+    @GetMapping
+    fun readAll(
+        @Auth loginMember: LoginMember,
+        request: ReadAllNotificationRequest,
+    ): ReadAllNotificationResponse {
+        val query = request.toQuery(loginMember.memberId)
+        return notificationService.readAllNotification(query)
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
+++ b/src/main/kotlin/com/petqua/presentation/notification/NotificationController.kt
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
-@RequestMapping("/notifications")
 @Tag(name = "Notification", description = "알림 관련 API 명세")
+@RequestMapping("/notifications")
 @RestController
 class NotificationController(
     private val notificationService: NotificationService,

--- a/src/main/kotlin/com/petqua/presentation/notification/dto/NotificationDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/notification/dto/NotificationDtos.kt
@@ -1,0 +1,29 @@
+package com.petqua.presentation.notification.dto
+
+import com.petqua.application.notification.dto.ReadAllNotificationQuery
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ReadAllNotificationRequest(
+    @Schema(
+        description = "마지막으로 조회한 알림의 Id",
+        example = "1"
+    )
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+
+    @Schema(
+        description = "조회할 알림 개수",
+        defaultValue = "20"
+    )
+    val limit: Int = PAGING_LIMIT_CEILING,
+) {
+    
+    fun toQuery(memberId: Long): ReadAllNotificationQuery {
+        return ReadAllNotificationQuery(
+            memberId = memberId,
+            lastViewedId = lastViewedId,
+            limit = limit,
+        )
+    }
+}

--- a/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
@@ -1,0 +1,64 @@
+package com.petqua.application.notification
+
+import com.petqua.application.notification.dto.ReadAllNotificationQuery
+import com.petqua.domain.member.MemberRepository
+import com.petqua.domain.notification.NotificationRepository
+import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.member
+import com.petqua.test.fixture.notification
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+
+@SpringBootTest(webEnvironment = NONE)
+class NotificationServiceTest(
+    private val notificationService: NotificationService,
+    private val notificationRepository: NotificationRepository,
+    private val memberRepository: MemberRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    Given("회원을 기준으로 알림을 조회 할 수 있다.") {
+        val memberId = memberRepository.save(member()).id
+
+        notificationRepository.saveAll(
+            listOf(
+                notification(memberId = memberId, title = "알림1"),
+                notification(memberId = memberId, title = "알림2"),
+                notification(memberId = memberId, title = "알림3"),
+                notification(memberId = memberId, title = "알림4"),
+                notification(memberId = memberId, title = "알림5"),
+            )
+        )
+
+        When("알림을 조회 하면") {
+            val query = ReadAllNotificationQuery(memberId = memberId)
+            val response = notificationService.readAllNotification(query)
+
+            Then("최신순으로 조회 된다.") {
+                assertSoftly(response) {
+                    notifications.sortedByDescending { it.createdAt }
+                }
+            }
+        }
+
+        When("조회 조건을 포함 하면") {
+            val query = ReadAllNotificationQuery(memberId = memberId, lastViewedId = 4, limit = 2)
+            val response = notificationService.readAllNotification(query)
+
+            Then("마지막으로 조회한 알림 이후의 알림만 조회 된다.") {
+                assertSoftly(response) {
+                    notifications.sortedByDescending { it.createdAt }
+                    notifications.first().id shouldBe 3
+                    hasNextPage shouldBe true
+                }
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
@@ -58,6 +58,28 @@ class NotificationServiceTest(
         }
     }
 
+    Given("회원을 기준으로 읽지 않은 알림의 개수를 조회 할 수 있다.") {
+        val memberId = memberRepository.save(member()).id
+
+        notificationRepository.saveAll(
+            listOf(
+                notification(memberId = memberId, title = "알림1", isRead = false),
+                notification(memberId = memberId, title = "알림2", isRead = false),
+                notification(memberId = memberId, title = "알림3", isRead = false),
+                notification(memberId = memberId, title = "알림4", isRead = true),
+                notification(memberId = memberId, title = "알림5", isRead = true),
+            )
+        )
+
+        When("읽지 않은 알림의 개수를 조회 하면") {
+            val count = notificationService.countUnreadNotifications(memberId)
+
+            Then("읽지 않은 알림의 개수가 조회 된다.") {
+                count shouldBe 3
+            }
+        }
+    }
+
     afterContainer {
         dataCleaner.clean()
     }

--- a/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/notification/NotificationServiceTest.kt
@@ -13,6 +13,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 
@@ -103,8 +104,11 @@ class NotificationServiceTest(
             notificationService.checkNotification(memberId, notificationId)
 
             Then("읽지 않은 알림의 개수가 갱신 된다.") {
-                val count = notificationService.countUnreadNotifications(memberId)
-                count shouldBe 0
+                val unreadNotificationCount = notificationService.countUnreadNotifications(memberId)
+                assertSoftly {
+                    previousUnreadNotificationCount shouldNotBe unreadNotificationCount
+                    unreadNotificationCount shouldBe 0
+                }
             }
         }
 

--- a/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
@@ -26,3 +26,18 @@ fun requestReadAllNotification(
         response()
     }
 }
+
+fun requestCountUnreadNotification(
+    accessToken: String,
+): Response {
+    return Given {
+        log().all()
+        auth().preemptive().oauth2(accessToken)
+    } When {
+        get("/notifications/unread/count")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
@@ -41,3 +41,20 @@ fun requestCountUnreadNotification(
         response()
     }
 }
+
+fun requestCheckNotification(
+    accessToken: String,
+    notificationId: Long,
+): Response {
+    return Given {
+        log().all()
+            .pathParam("notificationId", notificationId)
+        auth().preemptive().oauth2(accessToken)
+    } When {
+        patch("/notifications/{notificationId}/check")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerSteps.kt
@@ -1,0 +1,28 @@
+package com.petqua.presentation.notification
+
+import com.petqua.presentation.notification.dto.ReadAllNotificationRequest
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.restassured.response.Response
+
+fun requestReadAllNotification(
+    accessToken: String,
+    readAllNotificationRequest: ReadAllNotificationRequest,
+): Response {
+    return Given {
+        log().all()
+        auth().preemptive().oauth2(accessToken)
+        params(
+            "lastViewedId", readAllNotificationRequest.lastViewedId,
+            "limit", readAllNotificationRequest.limit,
+        )
+    } When {
+        get("/notifications")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerTest.kt
@@ -64,5 +64,30 @@ class NotificationControllerTest(
                 }
             }
         }
+
+        Given("회원에게 등록 된 읽지 않은 알림의 개수를") {
+            val accessToken = signInAsMember().accessToken
+            val memberId = getMemberIdByAccessToken(accessToken)
+
+            notificationRepository.saveAll(
+                listOf(
+                    notification(memberId = memberId, title = "알림1", isRead = false),
+                    notification(memberId = memberId, title = "알림2", isRead = false),
+                    notification(memberId = memberId, title = "알림3", isRead = false),
+                    notification(memberId = memberId, title = "알림4", isRead = true),
+                    notification(memberId = memberId, title = "알림5", isRead = true),
+                )
+            )
+
+            When("조회 할 수 있다") {
+                val response = requestCountUnreadNotification(
+                    accessToken = accessToken,
+                )
+
+                Then("읽지 않은 알림의 개수가 조회 된다") {
+                    response.`as`(Int::class.java) shouldBe 3
+                }
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/notification/NotificationControllerTest.kt
@@ -1,0 +1,68 @@
+package com.petqua.presentation.notification
+
+import com.petqua.application.notification.dto.ReadAllNotificationResponse
+import com.petqua.domain.notification.NotificationRepository
+import com.petqua.presentation.notification.dto.ReadAllNotificationRequest
+import com.petqua.test.ApiTestConfig
+import com.petqua.test.fixture.notification
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+
+class NotificationControllerTest(
+    private val notificationRepository: NotificationRepository,
+) : ApiTestConfig() {
+
+    init {
+        Given("회원에게 등록 된 알림을") {
+            val accessToken = signInAsMember().accessToken
+            val memberId = getMemberIdByAccessToken(accessToken)
+
+            notificationRepository.saveAll(
+                listOf(
+                    notification(memberId = memberId, title = "알림1"),
+                    notification(memberId = memberId, title = "알림2"),
+                    notification(memberId = memberId, title = "알림3"),
+                    notification(memberId = memberId, title = "알림4"),
+                    notification(memberId = memberId, title = "알림5"),
+                )
+            )
+
+            When("조회 할 수 있다") {
+                val response = requestReadAllNotification(
+                    accessToken = accessToken,
+                    readAllNotificationRequest = ReadAllNotificationRequest(
+                        lastViewedId = 4,
+                        limit = 2,
+                    )
+                )
+
+                Then("최신순으로 조회 된다") {
+                    val findNotificationResponse = response.`as`(ReadAllNotificationResponse::class.java)
+
+                    assertSoftly(findNotificationResponse) {
+                        notifications.sortedByDescending { it.createdAt }
+                        notifications.size shouldBe 2
+                        hasNextPage shouldBe true
+                    }
+                }
+            }
+
+            When("조회 조건을 입력 하지 않으면") {
+                val response = requestReadAllNotification(
+                    accessToken = accessToken,
+                    readAllNotificationRequest = ReadAllNotificationRequest(),
+                )
+
+                Then("지정된 기본값으로 조회 된다") {
+                    val findNotificationResponse = response.`as`(ReadAllNotificationResponse::class.java)
+
+                    assertSoftly(findNotificationResponse) {
+                        notifications.sortedByDescending { it.createdAt }
+                        notifications.size shouldBe 5
+                        hasNextPage shouldBe false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/petqua/test/fixture/NotificationFixture.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/NotificationFixture.kt
@@ -1,0 +1,17 @@
+package com.petqua.test.fixture
+
+import com.petqua.domain.notification.Notification
+
+fun notification(
+    memberId: Long = 0L,
+    title: String = "title",
+    content: String = "content",
+    isRead: Boolean = false,
+): Notification {
+    return Notification(
+        memberId = memberId,
+        title = title,
+        content = content,
+        isRead = isRead,
+    )
+}


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #111 

### 📁 작업 설명
- 알림 관련 API 추가
- [x] 알림 조회 API
- [x] 알림 읽음 처리 API
- [x] **읽지 않은 알림 개수 조회 API**

### 기타
[읽지 않은 알림 개수 조회 API] 결과를 캐싱 해두었습니다. 메인 페이지나 헤더에서 개수가 자주 필요할 것 같아서요..!
그래서 변동이 발생할 때, 캐싱을 비우는 로직을 추가하였습니다.
현재 읽지 않은 알림 개수의 변동이 존재하는 경우는 알림을 읽은 경우인데요. 이 로직에 캐싱을 비우도록 @CacheEvict를 사용하였습니다!