### PR TITLE
fix: 봉달 상품 수정시 수량을 포함 하여 중복 검사 하도록 수정

### DIFF
--- a/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
+++ b/src/main/kotlin/com/petqua/application/cart/CartProductService.kt
@@ -8,6 +8,7 @@ import com.petqua.common.domain.Money
 import com.petqua.common.domain.existByIdOrThrow
 import com.petqua.common.domain.findByIdOrThrow
 import com.petqua.common.util.throwExceptionWhen
+import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.cart.CartProductRepository
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.member.MemberRepository
@@ -49,7 +50,8 @@ class CartProductService(
             memberId = command.memberId,
             productId = command.productId,
             sex = command.sex,
-            deliveryMethod = command.deliveryMethod
+            deliveryMethod = command.deliveryMethod,
+            quantity = command.quantity,
         )
         validateSupportedOption(command.productId, command.sex)
         validateDeliveryFee(product, command.deliveryMethod, command.deliveryFee)
@@ -71,7 +73,8 @@ class CartProductService(
             memberId = command.memberId,
             productId = cartProduct.productId,
             sex = command.sex,
-            deliveryMethod = command.deliveryMethod
+            deliveryMethod = command.deliveryMethod,
+            quantity = command.quantity,
         )
         val product = productRepository.findByIdOrThrow(cartProduct.productId) {
             ProductException(NOT_FOUND_PRODUCT)
@@ -95,14 +98,15 @@ class CartProductService(
         memberId: Long,
         productId: Long,
         sex: Sex,
-        deliveryMethod: DeliveryMethod
+        deliveryMethod: DeliveryMethod,
+        quantity: CartProductQuantity,
     ) {
         cartProductRepository.findByMemberIdAndProductIdAndSexAndDeliveryMethod(
             memberId = memberId,
             productId = productId,
             sex = sex,
             deliveryMethod = deliveryMethod
-        )?.also { throw CartProductException(DUPLICATED_PRODUCT) }
+        )?.also { throwExceptionWhen(it.quantity == quantity) { throw CartProductException(DUPLICATED_PRODUCT) } }
     }
 
     fun delete(command: DeleteCartProductCommand) {

--- a/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/application/cart/dto/CartProductDtos.kt
@@ -12,7 +12,7 @@ import java.math.BigDecimal
 data class SaveCartProductCommand(
     val memberId: Long,
     val productId: Long,
-    val quantity: Int,
+    val quantity: CartProductQuantity,
     val sex: Sex,
     val deliveryMethod: DeliveryMethod,
     val deliveryFee: Money,
@@ -21,7 +21,7 @@ data class SaveCartProductCommand(
         return CartProduct(
             memberId = memberId,
             productId = productId,
-            quantity = CartProductQuantity(quantity),
+            quantity = quantity,
             sex = sex,
             deliveryMethod = deliveryMethod,
             deliveryFee = deliveryFee,

--- a/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/cart/dto/CartProductDtos.kt
@@ -7,7 +7,6 @@ import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.product.option.Sex
 import io.swagger.v3.oas.annotations.media.Schema
-import java.math.BigDecimal
 
 data class SaveCartProductRequest(
     @Schema(
@@ -47,7 +46,7 @@ data class SaveCartProductRequest(
         return SaveCartProductCommand(
             memberId = memberId,
             productId = productId,
-            quantity = quantity,
+            quantity = CartProductQuantity(quantity),
             sex = sex,
             deliveryMethod = DeliveryMethod.from(deliveryMethod),
             deliveryFee = deliveryFee,

--- a/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/cart/CartProductServiceTest.kt
@@ -234,7 +234,6 @@ class CartProductServiceTest(
             val command = updateCartProductOptionCommand(
                 cartProductId = cartProduct.id,
                 memberId = memberId,
-                quantity = 3,
                 sex = FEMALE,
                 deliveryMethod = SAFETY,
                 deliveryFee = 5000.toBigDecimal(),

--- a/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/cart/CartProductControllerTest.kt
@@ -223,6 +223,25 @@ class CartProductControllerTest(
                     response.statusCode shouldBe NO_CONTENT.value()
                 }
             }
+
+            When("수량만 변경 요청을 하면") {
+                val request = updateCartProductOptionRequest(
+                    quantity = 2,
+                    sex = MALE,
+                    deliveryMethod = "COMMON",
+                    deliveryFee = 3000.toBigDecimal(),
+                )
+
+                val response = requestUpdateCartProductOption(
+                    cartProductId,
+                    request,
+                    memberAuthResponse.accessToken
+                )
+
+                Then("중복 오류 없이 봉달 상품의 옵션이 수정된다") {
+                    response.statusCode shouldBe NO_CONTENT.value()
+                }
+            }
         }
 
         Given("봉달 상품의 옵션 수정시") {
@@ -344,7 +363,7 @@ class CartProductControllerTest(
                     memberAuthResponse.accessToken
                 )
                 val duplicationProductOptionRequest = updateCartProductOptionRequest(
-                    quantity = 2,
+                    quantity = 1,
                     sex = MALE,
                     deliveryMethod = "SAFETY",
                     deliveryFee = 5000.toBigDecimal(),

--- a/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
+++ b/src/test/kotlin/com/petqua/test/fixture/CartProductFixtures.kt
@@ -3,7 +3,6 @@ package com.petqua.test.fixture
 import com.petqua.application.cart.dto.SaveCartProductCommand
 import com.petqua.application.cart.dto.UpdateCartProductOptionCommand
 import com.petqua.common.domain.Money
-import com.petqua.common.util.setDefaultScale
 import com.petqua.domain.cart.CartProduct
 import com.petqua.domain.cart.CartProductQuantity
 import com.petqua.domain.delivery.DeliveryMethod
@@ -46,7 +45,7 @@ fun saveCartProductCommand(
     return SaveCartProductCommand(
         memberId = memberId,
         productId = productId,
-        quantity = quantity,
+        quantity = CartProductQuantity(quantity),
         sex = sex,
         deliveryMethod = deliveryMethod,
         deliveryFee = Money.from(deliveryFee),


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #116 

### 📁 작업 설명

- 설명
봉달 목록에 상품의 옵션을 수정할 때 수량만 다른 경우도 중복을 처리하는 로직 수정
상품, 성별, 배송 방식, 수량까지 모두 같은 경우에만 중복으로 판단하도록 변경
