### PR TITLE
feature: 로그아웃 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
@@ -51,7 +51,6 @@ class AuthFacadeService(
 
     fun signOut(accessToken: String, refreshToken: String) {
         val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
-        // TODO: 블랙 리스트 추가
-        authService.signOut(member)
+        authService.signOut(member, accessToken)
     }
 }

--- a/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
@@ -49,8 +49,8 @@ class AuthFacadeService(
         authService.delete(member)
     }
 
-    fun signOut(accessToken: String, refreshToken: String) {
+    fun logOut(accessToken: String, refreshToken: String) {
         val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
-        authService.signOut(member, accessToken)
+        authService.logOut(member, accessToken)
     }
 }

--- a/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
@@ -24,7 +24,7 @@ class AuthFacadeService(
 
     fun extendLogin(accessToken: String, refreshToken: String): AuthTokenInfo {
         authService.validateTokenExpiredStatusForExtendLogin(accessToken, refreshToken)
-        val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
+        val member = authService.findMemberBy(refreshToken = refreshToken)
         updateOauthTokenIfExpired(member)
         return authService.createAuthToken(member)
     }
@@ -50,7 +50,7 @@ class AuthFacadeService(
     }
 
     fun logOut(accessToken: String, refreshToken: String) {
-        val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
+        val member = authService.findMemberBy(refreshToken = refreshToken)
         authService.logOut(member, accessToken)
     }
 }

--- a/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthFacadeService.kt
@@ -2,8 +2,8 @@ package com.petqua.application.auth
 
 import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.member.Member
-import org.springframework.stereotype.Service
 import java.net.URI
+import org.springframework.stereotype.Service
 
 @Service
 class AuthFacadeService(
@@ -23,6 +23,7 @@ class AuthFacadeService(
     }
 
     fun extendLogin(accessToken: String, refreshToken: String): AuthTokenInfo {
+        authService.validateTokenExpiredStatusForExtendLogin(accessToken, refreshToken)
         val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
         updateOauthTokenIfExpired(member)
         return authService.createAuthToken(member)
@@ -46,5 +47,11 @@ class AuthFacadeService(
             oauthAccessToken = member.oauthAccessToken
         )
         authService.delete(member)
+    }
+
+    fun signOut(accessToken: String, refreshToken: String) {
+        val member = authService.findMemberBy(accessToken = accessToken, refreshToken = refreshToken)
+        // TODO: 블랙 리스트 추가
+        authService.signOut(member)
     }
 }

--- a/src/main/kotlin/com/petqua/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthService.kt
@@ -6,6 +6,7 @@ import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.auth.oauth.OauthTokenInfo
 import com.petqua.domain.auth.oauth.OauthUserInfo
 import com.petqua.domain.auth.token.AuthTokenProvider
+import com.petqua.domain.auth.token.BlackListTokenCacheStorage
 import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import com.petqua.domain.auth.token.findByTokenOrThrow
@@ -27,6 +28,7 @@ class AuthService(
     private val authTokenProvider: AuthTokenProvider,
     private val cartProductRepository: CartProductRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val blackListTokenCacheStorage: BlackListTokenCacheStorage,
 ) {
 
     fun findOrCreateMemberBy(
@@ -111,10 +113,11 @@ class AuthService(
         refreshTokenRepository.deleteByMemberId(member.id)
     }
 
-    fun signOut(member: Member) {
+    fun signOut(member: Member, accessToken: String) {
         member.signOut()
         memberRepository.save(member)
-        
+
         refreshTokenRepository.deleteByMemberId(member.id)
+        blackListTokenCacheStorage.save(member.id, accessToken)
     }
 }

--- a/src/main/kotlin/com/petqua/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthService.kt
@@ -113,7 +113,7 @@ class AuthService(
         refreshTokenRepository.deleteByMemberId(member.id)
     }
 
-    fun signOut(member: Member, accessToken: String) {
+    fun logOut(member: Member, accessToken: String) {
         member.signOut()
         memberRepository.save(member)
 

--- a/src/main/kotlin/com/petqua/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/petqua/application/auth/AuthService.kt
@@ -79,7 +79,7 @@ class AuthService(
     }
 
     @Transactional(readOnly = true)
-    fun findMemberBy(accessToken: String, refreshToken: String): Member {
+    fun findMemberBy(refreshToken: String): Member {
         val savedRefreshToken = refreshTokenRepository.findByTokenOrThrow(refreshToken) {
             AuthException(INVALID_REFRESH_TOKEN)
         }

--- a/src/main/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorage.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorage.kt
@@ -1,0 +1,26 @@
+package com.petqua.domain.auth.token
+
+import java.util.concurrent.TimeUnit
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class BlackListTokenCacheStorage(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val authTokenProperties: AuthTokenProperties,
+) {
+
+    fun save(memberId: Long, accessToken: String) {
+        redisTemplate.opsForValue().set(
+            "member:$memberId:accessToken",
+            accessToken,
+            authTokenProperties.accessTokenLiveTime,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    fun isBlackListed(memberId: Long, accessToken: String): Boolean {
+        val blackListToken = redisTemplate.opsForValue().get("member:$memberId:access")
+        return blackListToken == accessToken
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorage.kt
+++ b/src/main/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorage.kt
@@ -4,6 +4,9 @@ import java.util.concurrent.TimeUnit
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Repository
 
+
+private fun blackListKeyByMemberId(memberId: Long) = "member:$memberId:accessToken"
+
 @Repository
 class BlackListTokenCacheStorage(
     private val redisTemplate: RedisTemplate<String, String>,
@@ -12,7 +15,7 @@ class BlackListTokenCacheStorage(
 
     fun save(memberId: Long, accessToken: String) {
         redisTemplate.opsForValue().set(
-            "member:$memberId:accessToken",
+            blackListKeyByMemberId(memberId),
             accessToken,
             authTokenProperties.accessTokenLiveTime,
             TimeUnit.MILLISECONDS,
@@ -20,7 +23,7 @@ class BlackListTokenCacheStorage(
     }
 
     fun isBlackListed(memberId: Long, accessToken: String): Boolean {
-        val blackListToken = redisTemplate.opsForValue().get("member:$memberId:access")
+        val blackListToken = redisTemplate.opsForValue().get(blackListKeyByMemberId(memberId))
         return blackListToken == accessToken
     }
 }

--- a/src/main/kotlin/com/petqua/domain/member/Member.kt
+++ b/src/main/kotlin/com/petqua/domain/member/Member.kt
@@ -93,4 +93,10 @@ class Member(
         return oauthAccessTokenExpiresAt?.let { it < LocalDateTime.now() }
             ?: throw MemberException(INVALID_MEMBER_STATE)
     }
+
+    fun signOut() {
+        oauthAccessToken = DELETED_AUTH_FIELD
+        oauthAccessTokenExpiresAt = null
+        oauthRefreshToken = DELETED_AUTH_FIELD
+    }
 }

--- a/src/main/kotlin/com/petqua/exception/auth/AuthExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/auth/AuthExceptionType.kt
@@ -3,6 +3,7 @@ package com.petqua.exception.auth
 import com.petqua.common.exception.BaseExceptionType
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.UNAUTHORIZED
 
 enum class AuthExceptionType(
     private val httpStatus: HttpStatus,
@@ -17,6 +18,7 @@ enum class AuthExceptionType(
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "A11", "올바른 형태의 RefreshToken이 아닙니다."),
     INVALID_AUTH_HEADER(BAD_REQUEST, "A12", "올바른 형태의 Authorization 헤더가 아닙니다."),
     INVALID_AUTH_COOKIE(BAD_REQUEST, "A13", "올바른 형태의 쿠키가 아닙니다."),
+    UNABLE_ACCESS_TOKEN(UNAUTHORIZED, "A14", "사용할 수 없는 AccessToken입니다."),
 
     UNSUPPORTED_AUTHORITY(BAD_REQUEST, "A20", "해당하는 권한이 존재하지 않습니다."),
 

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -21,6 +21,7 @@ import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -121,6 +122,17 @@ class AuthController(
         @Auth loginMember: LoginMember
     ): ResponseEntity<Unit> {
         authFacadeService.deleteBy(loginMember.memberId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "로그아웃 API", description = "로그아웃 합니다")
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
+    @PatchMapping("/members/sign-out")
+    fun signOut(
+        @Parameter(hidden = true) @Auth authToken: AuthToken,
+    ): ResponseEntity<Unit> {
+        authFacadeService.signOut(authToken.accessToken, authToken.refreshToken)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthController.kt
@@ -129,10 +129,10 @@ class AuthController(
     @ApiResponse(responseCode = "204", description = "로그아웃 성공")
     @SecurityRequirement(name = ACCESS_TOKEN_SECURITY_SCHEME_KEY)
     @PatchMapping("/members/sign-out")
-    fun signOut(
+    fun logOut(
         @Parameter(hidden = true) @Auth authToken: AuthToken,
     ): ResponseEntity<Unit> {
-        authFacadeService.signOut(authToken.accessToken, authToken.refreshToken)
+        authFacadeService.logOut(authToken.accessToken, authToken.refreshToken)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/AuthExtractor.kt
@@ -5,6 +5,7 @@ import com.petqua.common.util.getCookieValueOrThrow
 import com.petqua.common.util.getHeaderOrThrow
 import com.petqua.common.util.throwExceptionWhen
 import com.petqua.domain.auth.token.AccessTokenClaims
+import com.petqua.domain.auth.token.BlackListTokenCacheStorage
 import com.petqua.domain.auth.token.JwtProvider
 import com.petqua.domain.member.MemberRepository
 import com.petqua.exception.auth.AuthException
@@ -12,6 +13,7 @@ import com.petqua.exception.auth.AuthExceptionType.EXPIRED_ACCESS_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.INVALID_ACCESS_TOKEN
 import com.petqua.exception.auth.AuthExceptionType.INVALID_AUTH_COOKIE
 import com.petqua.exception.auth.AuthExceptionType.INVALID_AUTH_HEADER
+import com.petqua.exception.auth.AuthExceptionType.UNABLE_ACCESS_TOKEN
 import com.petqua.exception.member.MemberException
 import com.petqua.exception.member.MemberExceptionType.NOT_FOUND_MEMBER
 import io.jsonwebtoken.ExpiredJwtException
@@ -27,6 +29,7 @@ private const val REFRESH_TOKEN = "refresh-token"
 class AuthExtractor(
     private val jwtProvider: JwtProvider,
     private val memberRepository: MemberRepository,
+    private val blackListTokenCacheStorage: BlackListTokenCacheStorage,
 ) {
 
     fun hasAuthorizationHeader(request: HttpServletRequest): Boolean {
@@ -57,6 +60,9 @@ class AuthExtractor(
             val accessTokenClaims = AccessTokenClaims.from(jwtProvider.getPayload(token))
             memberRepository.existActiveByIdOrThrow(accessTokenClaims.memberId) {
                 MemberException(NOT_FOUND_MEMBER)
+            }
+            throwExceptionWhen(blackListTokenCacheStorage.isBlackListed(accessTokenClaims.memberId, token)) {
+                AuthException(UNABLE_ACCESS_TOKEN)
             }
             return accessTokenClaims
         } catch (e: ExpiredJwtException) {

--- a/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
+++ b/src/main/kotlin/com/petqua/presentation/auth/TokenArgumentResolver.kt
@@ -28,6 +28,7 @@ class TokenArgumentResolver(
     ): AuthToken {
         val request = webRequest.getHttpServletRequestOrThrow()
         val accessToken = authExtractor.extractAccessToken(request)
+        authExtractor.validateBlacklistTokenRegardlessExpiration(accessToken)
         val refreshToken = authExtractor.extractRefreshToken(request)
         return AuthToken(accessToken, refreshToken)
     }

--- a/src/test/kotlin/com/petqua/application/auth/AuthFacadeServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/auth/AuthFacadeServiceTest.kt
@@ -4,6 +4,7 @@ import com.ninjasquad.springmockk.SpykBean
 import com.petqua.common.domain.findByIdOrThrow
 import com.petqua.domain.auth.oauth.OauthServerType.KAKAO
 import com.petqua.domain.auth.token.AuthTokenProvider
+import com.petqua.domain.auth.token.BlackListTokenCacheStorage
 import com.petqua.domain.auth.token.JwtProvider
 import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
@@ -33,6 +34,7 @@ class AuthFacadeServiceTest(
     private val authTokenProvider: AuthTokenProvider,
     private val jwtProvider: JwtProvider,
     private val memberRepository: MemberRepository,
+    private val blackListTokenCacheStorage: BlackListTokenCacheStorage,
     private val dataCleaner: DataCleaner,
 
     @SpykBean private val oauthService: OauthService,
@@ -275,6 +277,10 @@ class AuthFacadeServiceTest(
                     it.oauthAccessTokenExpiresAt shouldBe null
                     it.oauthRefreshToken shouldBe ""
                 }
+            }
+
+            Then("로그아웃한 회원의 토큰 정보를 블랙리스트에 추가한다") {
+                blackListTokenCacheStorage.isBlackListed(member.id, accessToken) shouldBe true
             }
         }
     }

--- a/src/test/kotlin/com/petqua/application/auth/AuthFacadeServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/auth/AuthFacadeServiceTest.kt
@@ -266,7 +266,7 @@ class AuthFacadeServiceTest(
         )
 
         When("회원의 인증 정보를 입력 하면") {
-            authFacadeService.signOut(accessToken, refreshToken)
+            authFacadeService.logOut(accessToken, refreshToken)
 
             Then("멤버의 토큰 정보와 RefreshToken이 초기화 된다") {
                 val signedOutMember = memberRepository.findByIdOrThrow(member.id)

--- a/src/test/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorageTest.kt
+++ b/src/test/kotlin/com/petqua/domain/auth/token/BlackListTokenCacheStorageTest.kt
@@ -1,0 +1,29 @@
+package com.petqua.domain.auth.token
+
+import com.petqua.domain.member.MemberRepository
+import com.petqua.test.fixture.member
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.Date
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+
+@SpringBootTest(webEnvironment = NONE)
+class BlackListTokenCacheStorageTest(
+    private val blackListTokenCacheStorage: BlackListTokenCacheStorage,
+    private val authTokenProvider: AuthTokenProvider,
+    private val memberRepository: MemberRepository,
+) : StringSpec({
+
+    "블랙리스트 추가 테스트" {
+        val member = memberRepository.save(member())
+        val authTokens = authTokenProvider.createAuthToken(member, Date())
+
+        blackListTokenCacheStorage.save(member.id, authTokens.accessToken)
+
+        assertSoftly {
+            blackListTokenCacheStorage.isBlackListed(member.id, authTokens.accessToken) shouldBe true
+        }
+    }
+})

--- a/src/test/kotlin/com/petqua/domain/member/MemberTest.kt
+++ b/src/test/kotlin/com/petqua/domain/member/MemberTest.kt
@@ -66,4 +66,25 @@ class MemberTest : StringSpec({
             member.validateDeleted()
         }.exceptionType() shouldBe NOT_FOUND_MEMBER
     }
+
+    "로그아웃 처리를 한다" {
+        val member = Member(
+            id = 1L,
+            oauthId = 1L,
+            oauthServerNumber = OauthServerType.KAKAO.number,
+            authority = Authority.MEMBER,
+            isDeleted = false,
+            oauthAccessToken = "oauthAccessToken",
+            oauthAccessTokenExpiresAt = LocalDateTime.now().plusSeconds(10000),
+            oauthRefreshToken = "oauthRefreshToken",
+        )
+
+        member.signOut()
+
+        assertSoftly(member) {
+            it.oauthAccessToken shouldBe ""
+            it.oauthAccessTokenExpiresAt shouldBe null
+            it.oauthRefreshToken shouldBe ""
+        }
+    }
 })

--- a/src/test/kotlin/com/petqua/presentation/auth/AuthControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/auth/AuthControllerSteps.kt
@@ -52,3 +52,20 @@ fun requestDeleteMember(
         response()
     }
 }
+
+fun requestSignOut(
+    accessToken: String,
+    refreshToken: String
+): Response {
+    return Given {
+        log().all()
+        auth().preemptive().oauth2(accessToken)
+        cookie("refresh-token", refreshToken)
+    } When {
+        patch("/auth/members/sign-out")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}

--- a/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/petqua/presentation/auth/AuthControllerTest.kt
@@ -3,11 +3,13 @@ package com.petqua.presentation.auth
 import com.ninjasquad.springmockk.SpykBean
 import com.petqua.application.auth.OauthService
 import com.petqua.common.domain.findByIdOrThrow
+import com.petqua.common.exception.ExceptionResponse
 import com.petqua.domain.auth.oauth.OauthServerType
 import com.petqua.domain.auth.token.AuthTokenProvider
 import com.petqua.domain.auth.token.RefreshToken
 import com.petqua.domain.auth.token.RefreshTokenRepository
 import com.petqua.domain.member.MemberRepository
+import com.petqua.exception.auth.AuthExceptionType.UNABLE_ACCESS_TOKEN
 import com.petqua.test.ApiTestConfig
 import com.petqua.test.fixture.member
 import io.kotest.assertions.assertSoftly
@@ -19,6 +21,7 @@ import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.HttpHeaders.SET_COOKIE
 import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.OK
+import org.springframework.http.HttpStatus.UNAUTHORIZED
 
 class AuthControllerTest(
     private val memberRepository: MemberRepository,
@@ -127,6 +130,32 @@ class AuthControllerTest(
                         it.oauthAccessTokenExpiresAt shouldBe null
                         it.oauthRefreshToken shouldBe ""
                     }
+                }
+            }
+        }
+
+        Given("로그아웃 된 인증정보로") {
+            val member = memberRepository.save(member())
+            val createAuthToken = authTokenProvider.createAuthToken(member, Date())
+            val accessToken = createAuthToken.accessToken
+            val refreshToken = createAuthToken.refreshToken
+            refreshTokenRepository.save(
+                RefreshToken(
+                    memberId = member.id,
+                    token = refreshToken
+                )
+            )
+            requestSignOut(accessToken, refreshToken)
+
+            When("인증이 필요한 요청에 사용하는 경우") {
+                val response = requestDeleteMember(accessToken)
+
+                Then("사용 할 수 없다") {
+                    val errorResponse = response.`as`(ExceptionResponse::class.java)
+                    assertSoftly(response) {
+                        statusCode shouldBe UNAUTHORIZED.value()
+                        errorResponse.message shouldBe UNABLE_ACCESS_TOKEN.errorMessage()
+                    }.statusCode shouldBe 401
                 }
             }
         }

--- a/src/test/kotlin/com/petqua/test/DataCleaner.kt
+++ b/src/test/kotlin/com/petqua/test/DataCleaner.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext
 import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,6 +25,9 @@ class DataCleaner(
 
     @Autowired
     val cacheManager: CacheManager,
+
+    @Autowired
+    val redisTemplate: RedisTemplate<String, Any>,
 ) {
 
     @Transactional
@@ -33,6 +37,7 @@ class DataCleaner(
         }
         truncateAllTables()
         clearCache()
+        clearRedis()
     }
 
     private fun initialize() {
@@ -52,5 +57,9 @@ class DataCleaner(
 
     private fun clearCache() {
         cacheManager.cacheNames.forEach { cacheManager.getCache(it)?.clear() }
+    }
+
+    private fun clearRedis() {
+        redisTemplate.keys("*").forEach { redisTemplate.delete(it) }
     }
 }

--- a/src/test/kotlin/com/petqua/test/DataCleaner.kt
+++ b/src/test/kotlin/com/petqua/test/DataCleaner.kt
@@ -60,6 +60,6 @@ class DataCleaner(
     }
 
     private fun clearRedis() {
-        redisTemplate.keys("*").forEach { redisTemplate.delete(it) }
+        redisTemplate.execute { connection -> connection.commands().flushDb() }
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #118 

### 📁 작업 설명
- 로그아웃 API 구현
로그아웃 시, 회원의 oauth 토큰 정보와 리프레시 토큰을 초기화 하였습니다.
추가로 사용중이던 인증정보에 대해 `사용할 수 없는(블랙리스트)` 인증 정보로 관리 되도록 구성하였습니다.

### 기타
블랙리스트 토큰 관리를 위해 Redis에 인증 정보들을 저장하였습니다.
저장 형식은 아래와 같습니다.
```
key - value
"member:${id}:accessToken" - "emj123mmnad0Bsd1.anboauhoEm1SVas.abahhjiaknl"
```
만료 시간은 accessToken의 만료시간과 동일하게 구성하였습니다!
