### PR TITLE
refactor: 상품 검색 시 정렬 조건 변경

### DIFF
--- a/src/main/kotlin/com/petqua/domain/keyword/ProductKeywordCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/keyword/ProductKeywordCustomRepositoryImpl.kt
@@ -25,7 +25,9 @@ class ProductKeywordCustomRepositoryImpl(
             ).whereAnd(
                 path(ProductKeyword::word).like(pattern = "%$word%", escape = ESCAPE_LETTER)
             ).orderBy(
-                length(path(ProductKeyword::word)).asc(), path(ProductKeyword::word).asc()
+                locate(word, path(ProductKeyword::word)).asc(),
+                length(path(ProductKeyword::word)).asc(),
+                path(ProductKeyword::word).asc()
             )
         }
 


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #121 

### 📁 작업 설명

- 회원가입 API 에서 어종 검색 기능을 개발하면서 기획의 변경이 생겨서 이를 반영했습니다.
![image](https://github.com/petqua/backend/assets/106813090/d86fe8d1-7599-4a5c-89fe-f7da20477e2c)

상품 검색 시에도 다음과 같은 정렬 조건을 따릅니다.
1. 검색어의 위치 오름차순
2. 글자수 오름차순
3. 글자 오름차순

