### PR TITLE
feature: 주문 내역 조회 api

### DIFF
--- a/src/main/kotlin/com/petqua/application/order/OrderService.kt
+++ b/src/main/kotlin/com/petqua/application/order/OrderService.kt
@@ -162,7 +162,7 @@ class OrderService(
     }
 
     @Transactional(readOnly = true)
-    fun findOrderNumberByMemberId(query: OrderReadQuery): OrdersResponse {
+    fun readAll(query: OrderReadQuery): OrdersResponse {
         validateOrderReadQuery(query)
         val orders = orderRepository.findOrdersByMemberId(query.memberId, query.toOrderPaging())
         orders.forEach { it.validateOwner(query.memberId) }

--- a/src/main/kotlin/com/petqua/application/order/OrderService.kt
+++ b/src/main/kotlin/com/petqua/application/order/OrderService.kt
@@ -2,9 +2,11 @@ package com.petqua.application.order
 
 import com.petqua.application.order.dto.OrderDetailReadQuery
 import com.petqua.application.order.dto.OrderProductCommand
+import com.petqua.application.order.dto.OrderReadQuery
 import com.petqua.application.order.dto.SaveOrderCommand
 import com.petqua.application.order.dto.SaveOrderResponse
 import com.petqua.application.payment.infra.PaymentGatewayClient
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.findByIdOrThrow
 import com.petqua.common.util.getOrThrow
 import com.petqua.common.util.throwExceptionWhen
@@ -28,6 +30,7 @@ import com.petqua.domain.product.option.ProductOptionRepository
 import com.petqua.domain.store.StoreRepository
 import com.petqua.exception.order.OrderException
 import com.petqua.exception.order.OrderExceptionType.EMPTY_SHIPPING_ADDRESS
+import com.petqua.exception.order.OrderExceptionType.NOT_INVALID_ORDER_READ_QUERY
 import com.petqua.exception.order.OrderExceptionType.ORDER_NOT_FOUND
 import com.petqua.exception.order.OrderExceptionType.PRODUCT_NOT_FOUND
 import com.petqua.exception.order.OrderExceptionType.STORE_NOT_FOUND
@@ -37,6 +40,7 @@ import com.petqua.exception.product.ProductException
 import com.petqua.exception.product.ProductExceptionType.NOT_FOUND_PRODUCT
 import com.petqua.presentation.order.dto.OrderDetailResponse
 import com.petqua.presentation.order.dto.OrderProductResponse
+import com.petqua.presentation.order.dto.OrdersResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -155,5 +159,40 @@ class OrderService(
             .associateBy { orderPayment -> orderPayment.orderId }
             .mapValues { it.value.status }
         return orders.map { OrderProductResponse(it, statusByOrderId.getOrThrow(it.id)) }
+    }
+
+    @Transactional(readOnly = true)
+    fun findOrderNumberByMemberId(query: OrderReadQuery): OrdersResponse {
+        validateOrderReadQuery(query)
+        val orders = orderRepository.findOrdersByMemberId(query.memberId, query.toOrderPaging())
+        orders.forEach { it.validateOwner(query.memberId) }
+        val ordersByOrderNumber = orders.groupBy { it.orderNumber }.toMutableMap()
+        val orderDetails = ordersByOrderNumber.mapValues { orderDetailResponseFromOrders(it.value) }
+        return OrdersResponse.of(orderDetails.values.toList(), query.limit)
+    }
+
+    private fun validateOrderReadQuery(query: OrderReadQuery) {
+        if (query.lastViewedId == DEFAULT_LAST_VIEWED_ID) {
+            return
+        }
+
+        val order = orderRepository.findByIdOrThrow(query.lastViewedId)
+        throwExceptionWhen(order.orderNumber != query.lastViewedOrderNumber) {
+            throw OrderException(NOT_INVALID_ORDER_READ_QUERY)
+        }
+    }
+
+    private fun orderDetailResponseFromOrders(orders: List<Order>): OrderDetailResponse {
+        val representativeOrder = orders[0]
+        val orderProductResponses = orders.map {
+            val orderStatus = orderPaymentRepository.findOrderStatusByOrderId(it.id)
+            OrderProductResponse(it, orderStatus.status)
+        }
+        return OrderDetailResponse(
+            orderNumber = representativeOrder.orderNumber.value,
+            orderedAt = representativeOrder.createdAt,
+            orderProducts = orderProductResponses,
+            totalAmount = representativeOrder.totalAmount,
+        )
     }
 }

--- a/src/main/kotlin/com/petqua/domain/order/OrderCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderCustomRepository.kt
@@ -1,0 +1,32 @@
+package com.petqua.domain.order
+
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+
+data class OrderPaging(
+    val lastViewedId: Long? = null,
+    val limit: Int = PAGING_LIMIT_CEILING,
+    val lastViewedOrderNumber: OrderNumber? = null,
+) {
+
+    companion object {
+        fun of(
+            lastViewedId: Long,
+            limit: Int,
+            lastViewedOrderNumber: OrderNumber?,
+        ): OrderPaging {
+            val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
+            val adjustedLimit = if (limit > PAGING_LIMIT_CEILING) PAGING_LIMIT_CEILING else limit
+            return OrderPaging(adjustedLastViewedId, adjustedLimit + PADDING_FOR_HAS_NEXT_PAGE, lastViewedOrderNumber)
+        }
+    }
+}
+
+interface OrderCustomRepository {
+
+    fun findOrdersByMemberId(
+        memberId: Long,
+        orderPaging: OrderPaging,
+    ): List<Order>
+}

--- a/src/main/kotlin/com/petqua/domain/order/OrderCustomRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderCustomRepository.kt
@@ -2,11 +2,12 @@ package com.petqua.domain.order
 
 import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
 import com.petqua.common.domain.dto.PADDING_FOR_HAS_NEXT_PAGE
-import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+
+private const val ORDER_PAGING_LIMIT_CEILING = 5
 
 data class OrderPaging(
     val lastViewedId: Long? = null,
-    val limit: Int = PAGING_LIMIT_CEILING,
+    val limit: Int = ORDER_PAGING_LIMIT_CEILING,
     val lastViewedOrderNumber: OrderNumber? = null,
 ) {
 
@@ -17,7 +18,7 @@ data class OrderPaging(
             lastViewedOrderNumber: OrderNumber?,
         ): OrderPaging {
             val adjustedLastViewedId = if (lastViewedId == DEFAULT_LAST_VIEWED_ID) null else lastViewedId
-            val adjustedLimit = if (limit > PAGING_LIMIT_CEILING) PAGING_LIMIT_CEILING else limit
+            val adjustedLimit = if (limit > ORDER_PAGING_LIMIT_CEILING) ORDER_PAGING_LIMIT_CEILING else limit
             return OrderPaging(adjustedLastViewedId, adjustedLimit + PADDING_FOR_HAS_NEXT_PAGE, lastViewedOrderNumber)
         }
     }

--- a/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.petqua.domain.order
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import com.petqua.common.util.createQuery
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+
+@Repository
+class OrderCustomRepositoryImpl(
+    private val entityManager: EntityManager,
+    private val jpqlRenderContext: JpqlRenderContext,
+    private val jpqlRenderer: JpqlRenderer,
+) : OrderCustomRepository {
+
+    override fun findOrdersByMemberId(
+        memberId: Long,
+        orderPaging: OrderPaging,
+    ): List<Order> {
+        val latestOrderNumbers = findLatestOrderNumbers(memberId, orderPaging)
+        val query = jpql {
+            select(
+                entity(Order::class),
+            ).from(
+                entity(Order::class),
+            ).whereAnd(
+                path(Order::orderNumber)(OrderNumber::value).`in`(latestOrderNumbers),
+            ).orderBy(
+                path(Order::createdAt).desc()
+            )
+        }
+
+        return entityManager.createQuery(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer,
+        )
+    }
+
+    private fun findLatestOrderNumbers(
+        memberId: Long,
+        paging: OrderPaging,
+    ): List<String> {
+        val query = jpql(OrderDynamicJpqlGenerator) {
+            selectDistinct(
+                path(Order::orderNumber)(OrderNumber::value)
+            ).from(
+                entity(Order::class)
+            ).whereAnd(
+                path(Order::memberId).eq(memberId),
+                orderIdLt(paging.lastViewedId),
+                orderNumberNotEq(paging.lastViewedOrderNumber),
+            ).orderBy(
+                path(Order::createdAt).desc()
+            )
+        }
+
+        return entityManager.createQuery<String>(
+            query,
+            jpqlRenderContext,
+            jpqlRenderer,
+            paging.limit,
+        )
+    }
+}

--- a/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
@@ -20,12 +20,16 @@ class OrderCustomRepositoryImpl(
         orderPaging: OrderPaging,
     ): List<Order> {
         val latestOrderNumbers = findLatestOrderNumbers(memberId, orderPaging)
+        if (latestOrderNumbers.isEmpty()) {
+            return emptyList()
+        }
+        
         val query = jpql {
             select(
                 entity(Order::class),
             ).from(
                 entity(Order::class),
-            ).whereAnd(
+            ).where(
                 path(Order::orderNumber)(OrderNumber::value).`in`(latestOrderNumbers),
             ).orderBy(
                 path(Order::createdAt).desc()

--- a/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderCustomRepositoryImpl.kt
@@ -23,7 +23,7 @@ class OrderCustomRepositoryImpl(
         if (latestOrderNumbers.isEmpty()) {
             return emptyList()
         }
-        
+
         val query = jpql {
             select(
                 entity(Order::class),
@@ -32,7 +32,7 @@ class OrderCustomRepositoryImpl(
             ).where(
                 path(Order::orderNumber)(OrderNumber::value).`in`(latestOrderNumbers),
             ).orderBy(
-                path(Order::createdAt).desc()
+                path(Order::id).desc()
             )
         }
 
@@ -57,7 +57,7 @@ class OrderCustomRepositoryImpl(
                 orderIdLt(paging.lastViewedId),
                 orderNumberNotEq(paging.lastViewedOrderNumber),
             ).orderBy(
-                path(Order::createdAt).desc()
+                path(Order::id).desc()
             )
         }
 

--- a/src/main/kotlin/com/petqua/domain/order/OrderDynamicJpqlGenerator.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderDynamicJpqlGenerator.kt
@@ -1,0 +1,20 @@
+package com.petqua.domain.order
+
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
+
+class OrderDynamicJpqlGenerator : Jpql() {
+    companion object Constructor : JpqlDsl.Constructor<OrderDynamicJpqlGenerator> {
+        override fun newInstance(): OrderDynamicJpqlGenerator = OrderDynamicJpqlGenerator()
+    }
+
+    fun Jpql.orderNumberNotEq(orderNumber: OrderNumber?): Predicate? {
+        return orderNumber?.let { path(Order::orderNumber).notEqual(it) }
+    }
+
+    fun Jpql.orderIdLt(lastViewedId: Long?): Predicate? {
+        return lastViewedId?.let { path(Order::id).lt(it) }
+    }
+}
+

--- a/src/main/kotlin/com/petqua/domain/order/OrderPaymentRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderPaymentRepository.kt
@@ -34,4 +34,19 @@ interface OrderPaymentRepository : JpaRepository<OrderPayment, Long> {
 
     @Query("SELECT op FROM OrderPayment op WHERE op.orderId = :orderId ORDER BY op.id DESC LIMIT 1")
     fun findOrderStatusByOrderId(orderId: Long): OrderPayment
+
+    @Query(
+        """
+        SELECT op 
+        FROM OrderPayment op
+        WHERE op.id IN (
+            SELECT MAX(op2.id) 
+            FROM OrderPayment op2
+            WHERE op2.orderId IN :orderIds 
+            GROUP BY op2.orderId
+        )
+        ORDER BY op.id DESC
+    """
+    )
+    fun findOrderStatusByOrderIds(orderIds: List<Long>): List<OrderPayment>
 }

--- a/src/main/kotlin/com/petqua/domain/order/OrderRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderRepository.kt
@@ -10,7 +10,7 @@ fun OrderRepository.findByOrderNumberOrThrow(
     return orders.ifEmpty { throw exceptionSupplier() }
 }
 
-interface OrderRepository : JpaRepository<Order, Long> {
+interface OrderRepository : JpaRepository<Order, Long>, OrderCustomRepository {
 
     fun findByOrderNumber(orderNumber: OrderNumber): List<Order>
 }

--- a/src/main/kotlin/com/petqua/domain/order/OrderRepository.kt
+++ b/src/main/kotlin/com/petqua/domain/order/OrderRepository.kt
@@ -13,4 +13,21 @@ fun OrderRepository.findByOrderNumberOrThrow(
 interface OrderRepository : JpaRepository<Order, Long>, OrderCustomRepository {
 
     fun findByOrderNumber(orderNumber: OrderNumber): List<Order>
+
+//    @Query(
+//        """
+//        SELECT o
+//        FROM Order o
+//        WHERE o.memberId = :memberId AND o.orderNumber
+//        IN (
+//            SELECT DISTINCT o2.orderNumber
+//            FROM Order o2
+//            WHERE o2.memberId = :memberId
+//            AND o2.id < :#{#paging.lastViewedId}
+//            ORDER BY o2.createdAt DESC
+//            LIMIT :#{#paging.limit}
+//        )
+//        """
+//    )
+//    fun findRecentDateOrdersByMemberId(memberId: Long, paging: OrderPaging): List<Order>
 }

--- a/src/main/kotlin/com/petqua/exception/order/OrderExceptionType.kt
+++ b/src/main/kotlin/com/petqua/exception/order/OrderExceptionType.kt
@@ -26,6 +26,8 @@ enum class OrderExceptionType(
     FORBIDDEN_ORDER(FORBIDDEN, "O30", "해당 주문에 대한 권한이 없습니다."),
     ORDER_CAN_NOT_CANCEL(BAD_REQUEST, "O31", "취소할 수 없는 주문입니다."),
     ORDER_CAN_NOT_PAY(BAD_REQUEST, "O32", "결제할 수 없는 주문입니다."),
+
+    NOT_INVALID_ORDER_READ_QUERY(BAD_REQUEST, "O40", "유효하지 않은 주문 조회 조건입니다."),
     ;
 
     override fun httpStatus(): HttpStatus {

--- a/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
@@ -41,7 +41,7 @@ class OrderController(
 
     @Operation(summary = "주문 상세 조회 API", description = "주문 상세를 조회합니다")
     @ApiResponse(responseCode = "200", description = "주문 상세 조회 성공")
-    @GetMapping
+    @GetMapping("/detail")
     fun readDetail(
         @Auth loginMember: LoginMember,
         @RequestParam orderNumber: String,

--- a/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/OrderController.kt
@@ -7,6 +7,8 @@ import com.petqua.common.config.ACCESS_TOKEN_SECURITY_SCHEME_KEY
 import com.petqua.domain.auth.Auth
 import com.petqua.domain.auth.LoginMember
 import com.petqua.presentation.order.dto.OrderDetailResponse
+import com.petqua.presentation.order.dto.OrderReadRequest
+import com.petqua.presentation.order.dto.OrdersResponse
 import com.petqua.presentation.order.dto.SaveOrderRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -48,6 +51,18 @@ class OrderController(
     ): ResponseEntity<OrderDetailResponse> {
         val query = OrderDetailReadQuery.of(loginMember.memberId, orderNumber)
         val response = orderService.readDetail(query)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "주문 내역 조회 API", description = "주문 내역을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "주문 내역 조회 성공")
+    @GetMapping
+    fun readAll(
+        @Auth loginMember: LoginMember,
+        @ModelAttribute request: OrderReadRequest,
+    ): ResponseEntity<OrdersResponse> {
+        val query = request.toQuery(loginMember)
+        val response = orderService.readAll(query)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
@@ -300,7 +300,7 @@ data class OrderReadRequest(
     val limit: Int = PAGING_LIMIT_CEILING,
 
     @Schema(
-        description = "마지막으로 조회한 주문 번호. 없을 경우 null",
+        description = "마지막으로 조회한 주문 번호. 없을 경우 EMPTY",
         example = "20210901000001"
     )
     val lastViewedOrderNumber: String,

--- a/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
@@ -258,3 +258,24 @@ data class OrderProductResponse(
         deliveryMethod = order.orderProduct.deliveryMethod.name,
     )
 }
+
+data class OrdersResponse(
+    val orders: List<OrderDetailResponse>,
+
+    @Schema(
+        description = "다음 페이지 존재 여부",
+        example = "true"
+    )
+    val hasNextPage: Boolean,
+) {
+
+    companion object {
+        fun of(orders: List<OrderDetailResponse>, limit: Int): OrdersResponse {
+            return if (orders.size > limit) {
+                OrdersResponse(orders.dropLast(1), hasNextPage = true)
+            } else {
+                OrdersResponse(orders, hasNextPage = false)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
+++ b/src/main/kotlin/com/petqua/presentation/order/dto/OrderDtos.kt
@@ -1,8 +1,12 @@
 package com.petqua.presentation.order.dto
 
 import com.petqua.application.order.dto.OrderProductCommand
+import com.petqua.application.order.dto.OrderReadQuery
 import com.petqua.application.order.dto.SaveOrderCommand
 import com.petqua.common.domain.Money
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.common.domain.dto.PAGING_LIMIT_CEILING
+import com.petqua.domain.auth.LoginMember
 import com.petqua.domain.delivery.DeliveryMethod
 import com.petqua.domain.order.Order
 import com.petqua.domain.order.OrderStatus
@@ -278,4 +282,43 @@ data class OrdersResponse(
             }
         }
     }
+}
+
+const val INITIAL_READ_ORDER_NUMBER = "EMPTY"
+
+data class OrderReadRequest(
+    @Schema(
+        description = "마지막으로 조회한 주문의 Id. 없을 경우 -1",
+        example = "1"
+    )
+    val lastViewedId: Long = DEFAULT_LAST_VIEWED_ID,
+
+    @Schema(
+        description = "조회할 주문의 개수",
+        defaultValue = "20"
+    )
+    val limit: Int = PAGING_LIMIT_CEILING,
+
+    @Schema(
+        description = "마지막으로 조회한 주문 번호. 없을 경우 null",
+        example = "20210901000001"
+    )
+    val lastViewedOrderNumber: String,
+) {
+
+    fun toQuery(loginMember: LoginMember): OrderReadQuery {
+        return OrderReadQuery.of(
+            memberId = loginMember.memberId,
+            lastViewedId = lastViewedId,
+            limit = limit,
+            lastViewedOrderNumber = adjustInitialReadOrderNumber(lastViewedOrderNumber),
+        )
+    }
+
+    private fun adjustInitialReadOrderNumber(lastViewedOrderNumber: String) =
+        if (lastViewedOrderNumber == INITIAL_READ_ORDER_NUMBER) {
+            null
+        } else {
+            lastViewedOrderNumber
+        }
 }

--- a/src/test/kotlin/com/petqua/application/order/OrderServiceTest.kt
+++ b/src/test/kotlin/com/petqua/application/order/OrderServiceTest.kt
@@ -797,7 +797,7 @@ class OrderServiceTest(
                 limit = 2,
                 lastViewedOrderNumber = null,
             )
-            val result = orderService.findOrderNumberByMemberId(query)
+            val result = orderService.readAll(query)
 
             Then("주문 내역이 조회된다.") {
                 assertSoftly(result) {
@@ -816,7 +816,7 @@ class OrderServiceTest(
                 limit = 2,
                 lastViewedOrderNumber = orderNumberC,
             )
-            val result = orderService.findOrderNumberByMemberId(query)
+            val result = orderService.readAll(query)
 
             Then("주문 내역이 조회된다.") {
                 assertSoftly(result) {
@@ -838,7 +838,7 @@ class OrderServiceTest(
 
             Then("예외가 발생 한다") {
                 shouldThrow<OrderException> {
-                    orderService.findOrderNumberByMemberId(query)
+                    orderService.readAll(query)
                 }.exceptionType() shouldBe (NOT_INVALID_ORDER_READ_QUERY)
             }
         }

--- a/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
@@ -83,6 +83,24 @@ class OrderCustomRepositoryImplTest(
 
             }
         }
+
+        When("회원의 주문이 존재하지 않는 경우") {
+            val neverOrderedMember = memberRepository.save(member())
+            val orderPagingRequest = OrderPaging.of(
+                lastViewedId = 1000,
+                limit = 1,
+                lastViewedOrderNumber = OrderNumber.from("202402211607020ORDERNUMBER")
+            )
+
+            val result = orderRepository.findOrdersByMemberId(
+                memberId = neverOrderedMember.id,
+                orderPaging = orderPagingRequest,
+            )
+
+            Then("빈 리스트가 반환된다.") {
+                result.size shouldBe 0
+            }
+        }
     }
 
     afterContainer {

--- a/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
@@ -7,7 +7,6 @@ import com.petqua.test.fixture.member
 import com.petqua.test.fixture.order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import java.time.LocalDateTime
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 
@@ -26,7 +25,6 @@ class OrderCustomRepositoryImplTest(
      */
     Given("주문을 조회 할 때") {
         val member = memberRepository.save(member())
-        val now = LocalDateTime.now()
 
         val orderNumberA = OrderNumber.from("202202211607020ORDERNUMBER")
         val orderA1 = order(memberId = member.id, orderNumber = orderNumberA, productName = "A1")
@@ -82,6 +80,7 @@ class OrderCustomRepositoryImplTest(
             Then("주문 내역이 조회된다.") {
                 result.size shouldBe 5
                 result.map { it.orderProduct.productName } shouldBe listOf("B2", "B1", "A3", "A2", "A1")
+
             }
         }
     }

--- a/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/com/petqua/domain/order/OrderCustomRepositoryImplTest.kt
@@ -1,0 +1,92 @@
+package com.petqua.domain.order
+
+import com.petqua.common.domain.dto.DEFAULT_LAST_VIEWED_ID
+import com.petqua.domain.member.MemberRepository
+import com.petqua.test.DataCleaner
+import com.petqua.test.fixture.member
+import com.petqua.test.fixture.order
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+
+@SpringBootTest(webEnvironment = NONE)
+class OrderCustomRepositoryImplTest(
+    private val orderRepository: OrderRepository,
+    private val memberRepository: MemberRepository,
+    private val dataCleaner: DataCleaner,
+) : BehaviorSpec({
+
+    /**
+     * 테스트 데이터 Order
+     * OrderA - A1, A2, A3
+     * OrderB - B1, B2
+     * OrderC - C1
+     */
+    Given("주문을 조회 할 때") {
+        val member = memberRepository.save(member())
+        val now = LocalDateTime.now()
+
+        val orderNumberA = OrderNumber.from("202202211607020ORDERNUMBER")
+        val orderA1 = order(memberId = member.id, orderNumber = orderNumberA, productName = "A1")
+        val orderA2 = order(memberId = member.id, orderNumber = orderNumberA, productName = "A2")
+        val orderA3 = order(memberId = member.id, orderNumber = orderNumberA, productName = "A3")
+
+        val orderNumberB = OrderNumber.from("202302211607020ORDERNUMBER")
+        val orderB1 = order(memberId = member.id, orderNumber = orderNumberB, productName = "B1")
+        val orderB2 = order(memberId = member.id, orderNumber = orderNumberB, productName = "B2")
+
+        val orderNumberC = OrderNumber.from("202402211607020ORDERNUMBER")
+        val orderC1 = order(memberId = member.id, orderNumber = orderNumberC, productName = "C1")
+
+        orderRepository.saveAll(
+            listOf(
+                orderA1, orderA2, orderA3,
+                orderB1, orderB2,
+                orderC1
+            )
+        )
+
+        When("최초 주문 조회시 주문ID와 주문번호는 입력 하지 않아도") {
+            val orderPagingRequest = OrderPaging.of(
+                lastViewedId = DEFAULT_LAST_VIEWED_ID, // 최초 조회 플래그
+                limit = 1,
+                lastViewedOrderNumber = null
+            )
+
+            val result = orderRepository.findOrdersByMemberId(
+                memberId = member.id,
+                orderPaging = orderPagingRequest,
+            )
+
+            Then("주문 내역이 조회된다.") {
+                result.forEach { println(it.orderProduct.productName) }
+                result.size shouldBe 3
+                result.map { it.orderProduct.productName } shouldBe listOf("C1", "B2", "B1")
+            }
+        }
+
+        When("마지막으로 조회된 주문의 ID와 주문 번호를 기준으로") {
+            val orderPagingRequest = OrderPaging.of(
+                lastViewedId = orderC1.id,
+                limit = 1,
+                lastViewedOrderNumber = orderNumberC
+            )
+
+            val result = orderRepository.findOrdersByMemberId(
+                memberId = member.id,
+                orderPaging = orderPagingRequest,
+            )
+
+            Then("주문 내역이 조회된다.") {
+                result.size shouldBe 5
+                result.map { it.orderProduct.productName } shouldBe listOf("B2", "B1", "A3", "A2", "A1")
+            }
+        }
+    }
+
+    afterContainer {
+        dataCleaner.clean()
+    }
+})

--- a/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
@@ -1,6 +1,7 @@
 package com.petqua.presentation.order
 
 import com.petqua.application.order.dto.SaveOrderResponse
+import com.petqua.presentation.order.dto.OrderReadRequest
 import com.petqua.presentation.order.dto.SaveOrderRequest
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
@@ -57,6 +58,25 @@ fun requestReadOrderDetail(
             .queryParams("orderNumber", orderNumber)
     } When {
         get("/orders/detail")
+    } Then {
+        log().all()
+    } Extract {
+        response()
+    }
+}
+
+fun requestReadAllOrder(
+    accessToken: String,
+    request: OrderReadRequest,
+): Response {
+    return Given {
+        log().all()
+        auth().preemptive().oauth2(accessToken)
+            .queryParams("lastViewedId", request.lastViewedId)
+            .queryParams("limit", request.limit)
+            .queryParams("lastViewedOrderNumber", request.lastViewedOrderNumber)
+    } When {
+        get("/orders")
     } Then {
         log().all()
     } Extract {

--- a/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
@@ -72,9 +72,11 @@ fun requestReadOrders(
     return Given {
         log().all()
         auth().preemptive().oauth2(accessToken)
-            .queryParams("lastViewedId", request.lastViewedId)
-            .queryParams("limit", request.limit)
-            .queryParams("lastViewedOrderNumber", request.lastViewedOrderNumber)
+            .params(
+                "lastViewedId", request.lastViewedId,
+                "limit", request.limit,
+                "lastViewedOrderNumber", request.lastViewedOrderNumber,
+            )
     } When {
         get("/orders")
     } Then {

--- a/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
@@ -65,7 +65,7 @@ fun requestReadOrderDetail(
     }
 }
 
-fun requestReadAllOrder(
+fun requestReadOrders(
     accessToken: String,
     request: OrderReadRequest,
 ): Response {

--- a/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
+++ b/src/test/kotlin/com/petqua/presentation/order/OrderControllerSteps.kt
@@ -56,7 +56,7 @@ fun requestReadOrderDetail(
         auth().preemptive().oauth2(accessToken)
             .queryParams("orderNumber", orderNumber)
     } When {
-        get("/orders")
+        get("/orders/detail")
     } Then {
         log().all()
     } Extract {


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 기입 -->
- closed #123 

### 📁 작업 설명
하단 화면에 필요한 데이터를 응답하는 API를 개발했습니다.
주문테이블이 따로 존재하지 않는 데이터 구조에서, 주문을 기준으로 페이징 조회를 위해 2번의 쿼리가 작성 되었습니다.
관련하여 코멘트 첨부하겠습니다!

---

페이징을 위해 id 기반으로 처리하는데 문제가 있었습니다.
현재 주문 테이블은 아래와 같은 구조인데요.
|주문id|주문번호|상품이름|...|
|---|---|---|---|
|1|OrderA|ProductA1|...|
|2|OrderA|ProductA2|...|
|3|OrderB|ProductB1|...|
|4|OrderC|ProductC1|...|
|5|OrderC|ProductC2|...|
|6|OrderD|ProductD1|...|

주문번호를 기준으로 페이징이 되다 보니 `lastViewedId` 이외로 `lastViewOrderNumber`도 추가적으로 요청을 받게했습니다.

</br>

위 데이터를 기준으로 `[2개의 주문 조회]` 를 하는 경우 아래와 같은 데이터가 응답됩니다.

|주문id|주문번호|상품이름|...|
|---|---|---|---|
|6|OrderD|ProductD1|...|
|5|OrderC|ProductC2|...|
|4|OrderC|ProductC1|...|

이때, 마지막 주문번호(`OrderC`)에 해당하는 주문Id는 4, 5가 모두 존재합니다.
다음 페이지를 분명하게 조회하기 위해 `lastViewedId`와 `lastViewOrderNumber`를 모두 전달받도록 구성하였습니다.
최초 조회시 `lastViewedId = -1(기존 방식)`, `lastViewOrderNumber = "EMPTY"` 의 값을 활용하였습니다.


### 📸 작업화면(선택)
<img width="331" alt="Screenshot 2024-05-17 at 11 58 28" src="https://github.com/petqua/backend/assets/90550065/31a9afa4-7b45-479e-96e6-ca1eb268475a">

`Json 응답 예시`
```json
{
    "orders": [
        {
            "orderNumber": "202402211607020ORDERNUMBER",
            "orderedAt": "2024-05-17T11:56:19.44041",
            "orderProducts": [
                {
                    "orderId": 6,
                    "orderStatus": "ORDER_CREATED",
                    "productId": 0,
                    "storeId": 0,
                    "storeName": "storeName",
                    "thumbnail": "image.url",
                    "productName": "C1",
                    "quantity": 1,
                    "sex": "FEMALE",
                    "orderPrice": 1,
                    "price": 1,
                    "deliveryFee": 3000,
                    "deliveryMethod": "SAFETY"
                }
            ],
            "totalAmount": 3001
        },
        {
            "orderNumber": "202302211607020ORDERNUMBER",
            "orderedAt": "2024-05-17T11:56:19.440209",
            "orderProducts": [
                {
                    "orderId": 5,
                    "orderStatus": "ORDER_CREATED",
                    "productId": 0,
                    "storeId": 0,
                    "storeName": "storeName",
                    "thumbnail": "image.url",
                    "productName": "B2",
                    "quantity": 1,
                    "sex": "FEMALE",
                    "orderPrice": 1,
                    "price": 1,
                    "deliveryFee": 3000,
                    "deliveryMethod": "SAFETY"
                },
                {
                    "orderId": 4,
                    "orderStatus": "ORDER_CREATED",
                    "productId": 0,
                    "storeId": 0,
                    "storeName": "storeName",
                    "thumbnail": "image.url",
                    "productName": "B1",
                    "quantity": 1,
                    "sex": "FEMALE",
                    "orderPrice": 1,
                    "price": 1,
                    "deliveryFee": 3000,
                    "deliveryMethod": "SAFETY"
                }
            ],
            "totalAmount": 3001
        }
    ],
    "hasNextPage": true
}
```

### 기타
